### PR TITLE
design: 카드 컴포넌트 추가

### DIFF
--- a/client/src/components/common/Card.style.tsx
+++ b/client/src/components/common/Card.style.tsx
@@ -1,0 +1,143 @@
+import styled from 'styled-components';
+import { COLOR } from '../../constants';
+import { RxHeartFilled } from 'react-icons/rx';
+import { IoMdEye } from 'react-icons/io';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  border: 1px solid ${({ theme }) => theme.themeStyle.cardBorderColor};
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.themeStyle.cardColor};
+  box-shadow: 0px 10px 30px -20px rgba(0, 0, 0, 0.25);
+  transition: transform 300ms;
+
+  :hover {
+    transform: scale(1.02);
+    cursor: pointer;
+  }
+`;
+
+export const Thumbnail = styled.div`
+  width: 100%;
+  height: 196px;
+  border-radius: 12px 12px 0 0;
+  overflow: hidden;
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100% - 196px);
+  padding: 35px 40px;
+`;
+
+export const CardContentWrapper = styled.div`
+  h1 {
+    margin-bottom: 11px;
+    color: ${({ theme }) => theme.themeStyle.fontColor};
+    font-size: 18px;
+    font-weight: 700;
+    // 2줄 이상이면 말줄임
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  p {
+    margin-bottom: 23px;
+    color: ${({ theme }) => theme.themeStyle.cardFontColor};
+    font-size: 13px;
+    word-break: keep-all;
+
+    @media ${({ theme }) => theme.breakpoints.DESKTOPMIN} {
+      margin-bottom: 20px;
+    }
+  }
+`;
+
+export const CardInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const UserProfile = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const UserImage = styled.div`
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background-color: transparent;
+  overflow: hidden;
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const UserName = styled.strong`
+  margin-left: 5px;
+  font-size: 14px;
+`;
+
+export const TagWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const PostInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  div {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  span {
+    font-size: 13px;
+    color: ${COLOR.subFontColor};
+
+    @media ${({ theme }) => theme.breakpoints.DESKTOPMIN} {
+      font-size: 15px;
+    }
+  }
+`;
+
+export const ViewIcon = styled(IoMdEye)`
+  color: ${COLOR.subFontColor};
+
+  @media ${({ theme }) => theme.breakpoints.DESKTOPMIN} {
+    font-size: 19px;
+  }
+`;
+
+export const LikeIcon = styled(RxHeartFilled)`
+  color: ${COLOR.subFontColor};
+  font-size: 14px;
+
+  @media ${({ theme }) => theme.breakpoints.DESKTOPMIN} {
+    font-size: 16px;
+  }
+`;

--- a/client/src/components/common/Card.style.tsx
+++ b/client/src/components/common/Card.style.tsx
@@ -100,6 +100,7 @@ export const UserName = styled.strong`
 
 export const TagWrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
 `;

--- a/client/src/components/common/Card.tsx
+++ b/client/src/components/common/Card.tsx
@@ -1,4 +1,8 @@
 import * as S from './Card.style';
+import YellowTag from './YellowTag';
+
+// 임시 데이터
+const tagList = ['React', 'TypeScript', 'Redux'];
 
 function Card() {
   return (
@@ -27,8 +31,14 @@ function Card() {
             </S.UserImage>
             <S.UserName>사용자 이름</S.UserName>
           </S.UserProfile>
-          <S.TagWrapper>태그</S.TagWrapper>
+          <S.TagWrapper>
+            {/* TODO: index는 id로 수정 */}
+            {tagList.map((tag, index) => (
+              <YellowTag key={index}>{tag}</YellowTag>
+            ))}
+          </S.TagWrapper>
           <S.PostInfo>
+            {/* TODO: 조회수, 추천수 숫자로 교체하기 */}
             <div>
               <S.ViewIcon />
               <span>조회수</span>

--- a/client/src/components/common/Card.tsx
+++ b/client/src/components/common/Card.tsx
@@ -1,0 +1,47 @@
+import * as S from './Card.style';
+
+function Card() {
+  return (
+    <S.Container>
+      <S.Thumbnail>
+        <img
+          src='https://plus.unsplash.com/premium_photo-1672907031583-60041cf55a8f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80'
+          alt='포트폴리오 썸네일'
+        />
+      </S.Thumbnail>
+      <S.Content>
+        <S.CardContentWrapper>
+          <h1>&#91;테스트&#93; 길이가 긴 제목입니다</h1>
+          <p>
+            프로젝트 소개글을 남기는 곳. 소개글은 60자 제한이 있습니다. 너무 길지도, 짧지도 않게
+            작성해 주세요.
+          </p>
+        </S.CardContentWrapper>
+        <S.CardInfoWrapper>
+          <S.UserProfile>
+            <S.UserImage>
+              <img
+                src='https://i.pinimg.com/originals/28/e0/40/28e0405ea8da9e7e33030be5580d9053.png'
+                alt='프로필 이미지'
+              />
+            </S.UserImage>
+            <S.UserName>사용자 이름</S.UserName>
+          </S.UserProfile>
+          <S.TagWrapper>태그</S.TagWrapper>
+          <S.PostInfo>
+            <div>
+              <S.ViewIcon />
+              <span>조회수</span>
+            </div>
+            <div>
+              <S.LikeIcon />
+              <span>추천수</span>
+            </div>
+          </S.PostInfo>
+        </S.CardInfoWrapper>
+      </S.Content>
+    </S.Container>
+  );
+}
+
+export default Card;

--- a/client/src/style/theme.ts
+++ b/client/src/style/theme.ts
@@ -8,6 +8,8 @@ declare module 'styled-components' {
       backgroundColor: string;
       fontColor: string;
       cardColor: string;
+      cardFontColor: string;
+      cardBorderColor: string;
       inputColor: string;
       toggleColor: string;
       inputBorderColor: string;
@@ -27,6 +29,8 @@ export const lightTheme: DefaultTheme = {
     backgroundColor: '#ffffff',
     fontColor: '#000000',
     cardColor: '#ffffff',
+    cardFontColor: '#303030',
+    cardBorderColor: 'rgba(243, 243, 243, 0.8)',
     inputColor: '#ffffff',
     toggleColor: '#ccc',
     inputBorderColor: '#000000',
@@ -45,6 +49,8 @@ export const darkTheme: DefaultTheme = {
     backgroundColor: '#000000',
     fontColor: '#ffffff',
     cardColor: '#303030',
+    cardFontColor: '#C4C4C4',
+    cardBorderColor: '#303030',
     inputColor: '#303030',
     toggleColor: '#303030',
     inputBorderColor: '#ffffff',


### PR DESCRIPTION
### Branch
fe-feat/card/#33 => fe

### 참고 사항
- theme에 cardFontColor, cardBorderColor를 추가했습니다. 
- 카드 컴포넌트에 커서가 올라가면 카드 크기가 커지는 효과를 주었습니다. 
- 제목이 너무 긴 경우 카드 내부에 여백이 많아져서 제목에 말줄임 처리를 했습니다. (최대 2줄) 

**말줄임 처리 전**
<img width="701" alt="스크린샷 2023-05-06 오전 12 10 09" src="https://user-images.githubusercontent.com/77181642/236497188-b9344895-487f-4973-9c3c-8c4b1f12845e.png">

**말줄임 처리 후**
<img width="701" alt="스크린샷 2023-05-06 오전 12 10 51" src="https://user-images.githubusercontent.com/77181642/236497368-c2258007-e537-4d35-ae1e-4ab80f29cf06.png">

