### PR TITLE
fix:포트폴리오 작성 페이지, react quill 기능 수정 및 태그 수정

### DIFF
--- a/client/src/components/Portfolio/DetailBox.tsx
+++ b/client/src/components/Portfolio/DetailBox.tsx
@@ -10,56 +10,17 @@ type DetailBoxProps = {
 const modules = {
   toolbar: {
     container: [
+      ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+      ['blockquote', 'code-block'],
+      [{ list: 'ordered' }, { list: 'bullet' }],
+      [{ indent: '-1' }, { indent: '+1' }], // outdent/indent
+      [{ direction: 'rtl' }], // text direction
       [{ header: [1, 2, 3, 4, 5, 6, false] }],
+      [{ color: [] }, { background: [] }], // dropdown with defaults from theme
       [{ font: [] }],
       [{ align: [] }],
-      ['bold', 'italic', 'underline', 'strike', 'blockquote'],
-      [{ list: 'ordered' }, { list: 'bullet' }, 'link'],
-      [
-        {
-          color: [
-            '#000000',
-            '#e60000',
-            '#ff9900',
-            '#ffff00',
-            '#008a00',
-            '#0066cc',
-            '#9933ff',
-            '#ffffff',
-            '#facccc',
-            '#ffebcc',
-            '#ffffcc',
-            '#cce8cc',
-            '#cce0f5',
-            '#ebd6ff',
-            '#bbbbbb',
-            '#f06666',
-            '#ffc266',
-            '#ffff66',
-            '#66b966',
-            '#66a3e0',
-            '#c285ff',
-            '#888888',
-            '#a10000',
-            '#b26b00',
-            '#b2b200',
-            '#006100',
-            '#0047b2',
-            '#6b24b2',
-            '#444444',
-            '#5c0000',
-            '#663d00',
-            '#666600',
-            '#003700',
-            '#002966',
-            '#3d1466',
-            'custom-color',
-          ],
-        },
-        { background: [] },
-      ],
-      ['image', 'video'],
       ['clean'],
+      ['blackquote', 'link', 'image'],
     ],
   },
 };
@@ -73,6 +34,7 @@ const DetailBox: React.FC<DetailBoxProps> = ({ text }) => {
   return (
     <S.DetailContainer>
       <S.Title>{text}</S.Title>
+      <ReactQuill />
       <ReactQuill modules={modules} onChange={setContent} value={content} />
     </S.DetailContainer>
   );

--- a/client/src/components/Portfolio/NewPortfolioContainer.style.tsx
+++ b/client/src/components/Portfolio/NewPortfolioContainer.style.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import { COLOR, MAX_SIZE } from '../../constants';
-import { YellowBtn } from '../common/Button.style';
+
 const { mainColor, subFontColor } = COLOR;
 
 const { content } = MAX_SIZE;
 export const NewPortfolioLayout = styled.div`
+  width: 100%;
   margin: 5rem 0;
 
   @media ${(props) => props.theme.breakpoints.TABLETMIN} {
@@ -32,7 +33,7 @@ export const SubmitBtn = styled.button`
   background-color: ${mainColor};
   border-radius: 10px;
   font-weight: bold;
-
+  padding: 0.5rem;
   height: 30px;
 
   @media ${(props) => props.theme.breakpoints.TABLETMIN} {

--- a/client/src/components/Portfolio/TagBox.tsx
+++ b/client/src/components/Portfolio/TagBox.tsx
@@ -8,20 +8,18 @@ type TagBoxProps = {
 };
 
 const TagBox: React.FC<TagBoxProps> = ({ text }) => {
-  const initialTags = ['React'];
-
-  const [tags, setTags] = useState(initialTags);
+  const [tags, setTags] = useState([] as any);
   const removeTags = (indexToRemove: number) => {
-    setTags(tags.filter((it, index) => index !== indexToRemove));
+    setTags(tags.filter((it: string, index: number) => index !== indexToRemove));
   };
 
-  const addTags = (event: any) => {
-    const tag = event.target.value;
+  const addTags = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const tag = event.currentTarget.value;
     if (tags.includes(tag) || tag.length === 0) {
       console.log('Fail!');
       return;
     }
-    event.target.value = '';
+    event.currentTarget.value = '';
     setTags([...tags, tag]);
   };
 
@@ -30,7 +28,7 @@ const TagBox: React.FC<TagBoxProps> = ({ text }) => {
       <S.Title>{text}</S.Title>
       <S.TagEditor>
         <ul id='tags'>
-          {tags.map((tag, index) => (
+          {tags.map((tag: string, index: number) => (
             <li key={index} className='tag'>
               <span className='tag-title'>{tag}</span>
               <TiDeleteOutline className='tag-close-icon' onClick={() => removeTags(index)} />

--- a/client/src/style/GlobalStyle.ts
+++ b/client/src/style/GlobalStyle.ts
@@ -48,6 +48,15 @@ button{
 	background-color:transparent;
 	border:0;
 }
+u {
+    text-decoration: underline;
+}
+strong {
+    font-weight: bold;
+}
+em {
+    font-style: italic;
+}
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
Branch
fe-feat/포트폴리오 작성/#47=> fe

참고 사항
태그의 초기값이 빈 배열일 때 발생하느 타입 오류 현상을 수정했습니다. 
React-quill 에디터 내에서 기능이 적용안되는 현상이 있어서 수정 후, 코드블럭 기능 추가했습니다.
