### PR TITLE
feat: 포트폴리오 작성 페이지 ajax 적용(수정필요)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,8 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
         "axios": "^1.4.0",
+        "highlight.js": "^11.8.0",
+        "quill-image-resize-module-ts": "^3.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
@@ -8861,6 +8863,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14404,6 +14414,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
+    "node_modules/quill-image-resize-module-ts": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quill-image-resize-module-ts/-/quill-image-resize-module-ts-3.0.3.tgz",
+      "integrity": "sha512-NMWw67zCfGxE0AyPTVLWMTAs71eKerd+jJJqu9ZuPBGZl7vc+Jtb+tmfx33pC3h0deVYqgOMXYzbFBIRmu/WuQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "quill": "^1.3.4"
+      }
     },
     "node_modules/quill/node_modules/deep-equal": {
       "version": "1.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,8 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
     "axios": "^1.4.0",
+    "highlight.js": "^11.8.0",
+    "quill-image-resize-module-ts": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",

--- a/client/src/components/Portfolio/DetailBox.tsx
+++ b/client/src/components/Portfolio/DetailBox.tsx
@@ -1,40 +1,112 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as S from './DetailBox.style';
-import ReactQuill from 'react-quill';
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+import typescript from 'highlight.js/lib/languages/typescript';
+import c from 'highlight.js/lib/languages/c';
+import ReactQuill, { Quill } from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import { ImageResize } from 'quill-image-resize-module-ts';
+import axios from 'axios';
+
+Quill.register('modules/ImageResize', ImageResize);
 
 type DetailBoxProps = {
   text: string;
+  content: string;
+  setContent: React.Dispatch<React.SetStateAction<string>>;
 };
 
-const modules = {
-  toolbar: {
-    container: [
-      ['bold', 'italic', 'underline', 'strike'], // toggled buttons
-      ['blockquote', 'code-block'],
-      [{ list: 'ordered' }, { list: 'bullet' }],
-      [{ indent: '-1' }, { indent: '+1' }], // outdent/indent
-      [{ direction: 'rtl' }], // text direction
-      [{ header: [1, 2, 3, 4, 5, 6, false] }],
-      [{ color: [] }, { background: [] }], // dropdown with defaults from theme
-      [{ font: [] }],
-      [{ align: [] }],
-      ['clean'],
-      ['blackquote', 'link', 'image'],
-    ],
-  },
-};
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('c', c);
 
-const DetailBox: React.FC<DetailBoxProps> = ({ text }) => {
-  const setting =
-    '<p><br></p><h3><strong>*본 형식은 작성을 돕는 가이드일 뿐입니다, 자유로운 형식으로 작성해보세요*</strong></h3><p><br></p><h3>기간 : 2023.00.00 - 2023.00.00</h3><p><br></p><h3>Overview ｜ 프로젝트 요약</h3><p>본인이 진행한 프로젝트에서 어떤 일을 진행했는지 알 수 있도록 간결하게 설명해주세요</p><p><br></p><h3>Role ｜ 역할</h3><p>해당 프로젝트에서 본인이 기여한 정도와 역할을 작성해 주세요.</p><p>기여도 : 00%</p><p><br></p><h3>Function ｜ 기능</h3><p> 작동 화면과 간단한 설명으로 프로젝트에서 구현한 기능에 대해서 설명해주세요.</p><p><br></p><p><br></p><h3>Result ｜ 성과</h3><p>해당 프로젝트의 성과를 작성해 주세요. 수치, 숫자로 성과를 표현할 수 있다면 설득력이 높아져요. 수치로 표현하기 어려운 성과라면 정성적인 성과도 괜찮아요.</p><p><br></p><p><br></p><h3>Lesson-Learned ｜ 프로젝트 후 배운 것</h3><p>모든 프로젝트가 성공하지 못했더라도, 배운 점은 있을 거예요. 해당 프로젝트에서 배운 점, 아쉬웠던 점, 개선할 수 있는 점을 적어서 다음 프로젝트 진행 시에 이를 보완할 수 있다는 것을 어필해 보세요.</p>';
+const DetailBox: React.FC<DetailBoxProps> = ({ text, content, setContent }) => {
+  const quillRef = useRef<ReactQuill | null>(null);
+  // 이미지 처리를 하는 핸들러
+  const imageHandler = () => {
+    console.log('에디터에서 이미지 버튼을 클릭하면 이 핸들러가 시작됩니다!');
+    if (!quillRef.current) return;
+    const quillInstance: any = quillRef.current.getEditor();
+    // 1. 이미지를 저장할 input type=file DOM을 만든다.
+    const input = document.createElement('input');
+    // 속성 써주기
+    input.setAttribute('type', 'file');
+    input.setAttribute('accept', 'image/*');
+    input.click(); // 에디터 이미지버튼을 클릭하면 이 input이 클릭된다.
+    // input이 클릭되면 파일 선택창이 나타난다.
 
-  const [content, setContent] = useState(setting);
-  console.log(content);
+    input.onchange = async () => {
+      const file = input.files![0];
+      const formData = new FormData();
+      formData.append('image', file);
+
+      // 이미지를 서버로 전송 (서버 엔드포인트 주소를 사용)
+      const response = await axios.post('YOUR_SERVER_API_URL', {
+        body: formData,
+      });
+
+      const imageUrl = await response;
+      const range = quillInstance.getSelection(true);
+      quillInstance.insertEmbed(range.index, 'image', imageUrl);
+    };
+  };
+
+  const modules = useMemo(() => {
+    return {
+      // syntax: {
+      //   highlight: (text: any) => hljs.highlightAuto(text).value,
+      // },
+      toolbar: {
+        container: [
+          [{ header: [1, 2, false] }, { header: '2' }, { font: [String] }],
+          [{ size: [String] }],
+          ['bold', 'italic', 'underline', 'strike', 'blockquote'],
+          [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
+          ['link', 'image', 'code-block'],
+          ['clean'],
+        ],
+        // handlers: {
+        //   image: imageHandler,
+        // },
+      },
+      // 이미지 조절 시 오류
+      ImageResize: {
+        modules: ['Resize', 'DisplaySize', 'Toolbar'],
+      },
+    };
+  }, []);
+
+  const formats = [
+    'header',
+    'font',
+    'size',
+    'bold',
+    'italic',
+    'underline',
+    'strike',
+    'blockquote',
+    'list',
+    'bullet',
+    'indent',
+    'link',
+    'image',
+    'video',
+    'code-block',
+  ];
+
   return (
     <S.DetailContainer>
       <S.Title>{text}</S.Title>
-      <ReactQuill modules={modules} onChange={setContent} value={content} />
+      <ReactQuill
+        ref={quillRef}
+        modules={modules}
+        onChange={setContent}
+        value={content}
+        theme='snow'
+      />
     </S.DetailContainer>
   );
 };

--- a/client/src/components/Portfolio/ImgBox.tsx
+++ b/client/src/components/Portfolio/ImgBox.tsx
@@ -3,38 +3,24 @@ import * as S from './ImgBox.style';
 
 type ImgBoxProps = {
   text: string;
+  img: File | null;
+  selectFile: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-const ImgBox: React.FC<ImgBoxProps> = ({ text }) => {
-  const [imgName, setImgName] = useState<string>('');
-
+const ImgBox: React.FC<ImgBoxProps> = ({ text, img, selectFile }) => {
   return (
     <S.ImgContainer>
       <S.Title>{text}</S.Title>
       <S.ImgSelector>
-        {imgName ? (
-          <S.ImgName>{imgName}</S.ImgName>
+        {img ? (
+          <S.ImgName>{img.name}</S.ImgName>
         ) : (
           <S.ImgName className='gray-font'>{'사진을 선택해주세요'}</S.ImgName>
         )}
         <S.ImgInput htmlFor='file'>
           <span>업로드</span>
         </S.ImgInput>
-        <input
-          type='file'
-          className='file'
-          id='file'
-          onChange={(e) => {
-            if (e.currentTarget.files?.[0]) {
-              const file = e.currentTarget.files[0];
-              const reader = new FileReader();
-              reader.readAsDataURL(file);
-              reader.onloadend = (event) => {
-                setImgName(file.name);
-              };
-            }
-          }}
-        />
+        <input type='file' className='file' id='file' onChange={selectFile} />
       </S.ImgSelector>
     </S.ImgContainer>
   );

--- a/client/src/components/Portfolio/PortfolioContainer.tsx
+++ b/client/src/components/Portfolio/PortfolioContainer.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import * as S from './PortfolioContainer.style';
 import TextBox from './TextBox';
 import ImgBox from './ImgBox';
@@ -7,42 +7,135 @@ import TagBox from './TagBox';
 import TextareaBox from './TextareaBox';
 import DetailBox from './DetailBox';
 import UserBox from './UserBox';
+import useInput from '../../hooks/useInput';
+import { useRouter } from '../../hooks/useRouter';
 
 type PortfolioContainerProps = {
   isEdit: boolean;
 };
 
 const PortfolioContainer: React.FC<PortfolioContainerProps> = ({ isEdit }) => {
+  const { routeTo, backTo } = useRouter();
+  const setting =
+    '<p><br></p><h3><strong>*본 형식은 작성을 돕는 가이드일 뿐입니다, 자유로운 형식으로 작성해보세요*</strong></h3><p><br></p><h3>기간 : 2023.00.00 - 2023.00.00</h3><p><br></p><h3>Overview ｜ 프로젝트 요약</h3><p>본인이 진행한 프로젝트에서 어떤 일을 진행했는지 알 수 있도록 간결하게 설명해주세요</p><p><br></p><h3>Role ｜ 역할</h3><p>해당 프로젝트에서 본인이 기여한 정도와 역할을 작성해 주세요.</p><p>기여도 : 00%</p><p><br></p><h3>Function ｜ 기능</h3><p> 작동 화면과 간단한 설명으로 프로젝트에서 구현한 기능에 대해서 설명해주세요.</p><p><br></p><p><br></p><h3>Result ｜ 성과</h3><p>해당 프로젝트의 성과를 작성해 주세요. 수치, 숫자로 성과를 표현할 수 있다면 설득력이 높아져요. 수치로 표현하기 어려운 성과라면 정성적인 성과도 괜찮아요.</p><p><br></p><p><br></p><h3>Lesson-Learned ｜ 프로젝트 후 배운 것</h3><p>모든 프로젝트가 성공하지 못했더라도, 배운 점은 있을 거예요. 해당 프로젝트에서 배운 점, 아쉬웠던 점, 개선할 수 있는 점을 적어서 다음 프로젝트 진행 시에 이를 보완할 수 있다는 것을 어필해 보세요.</p>';
+  // 포트폴리오 정보
+  const title = useInput('');
+  const [img, setImg] = useState<File | null>(null);
+  const gitLink = useInput('');
+  const distributionLink = useInput('');
+  const [tags, setTags] = useState<string[]>([]);
+  const description = useInput('');
+  const [content, setContent] = useState(setting);
+
+  // tag 조작 함수
+  const removeTags = (indexToRemove: number) => {
+    setTags(tags.filter((it: string, index: number) => index !== indexToRemove));
+  };
+
+  const addTags = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const tag = event.currentTarget.value;
+    if (tags.includes(tag) || tag.length === 0) {
+      console.log('Fail!');
+      return;
+    }
+    event.currentTarget.value = '';
+    setTags([...tags, tag]);
+  };
+
+  // 파일 선택 함수
+  const selectFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.currentTarget.files?.[0]) {
+      const file = event.currentTarget.files[0];
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      setImg(file);
+    }
+  };
+
+  const postPortFolio = async () => {
+    // form 형태로 전달
+    const body = new FormData();
+    const data = {
+      // id: String(Math.floor(Math.random() * 10000)),
+      userId: 1,
+      title: title.value,
+      // img: img,
+      gitLink: gitLink.value,
+      distributionLink: distributionLink.value,
+      // tags: tags,
+      description: description.value,
+      content,
+    };
+
+    console.log(JSON.stringify(data));
+    // blob 형태로 변환 후 form에 추가
+    const blob = new Blob([JSON.stringify(data)], {
+      type: 'application/json',
+    });
+    body.append('portfolio', blob);
+
+    // blob에서 정보 받아오기
+    const text = await new Response(blob).text();
+    // console.log(JSON.parse(text));
+
+    const res = await axios.post('http://43.201.157.191:8080/portfolios', data, {
+      // headers: {
+      //   'Content-Type': 'multipart/form-data',
+      // },
+    });
+  };
+
+  const getPortFolio = async () => {
+    const { data } = await axios.get('http://43.201.157.191:8080/portfolios/1');
+    const portfolio = data;
+  };
+
+  useEffect(() => {
+    if (isEdit) {
+      getPortFolio();
+    }
+  }, [isEdit]);
+
   return (
     <S.PortfolioLayout>
       {isEdit ? (
         <>
           <UserBox />
-          <TextBox text={'제목'} />
-          <ImgBox text={'대표 사진'} />
-          <TextBox text={'깃허브 링크'} />
-          <TextBox text={'배포 링크'} />
-          <TagBox text={'기술스택(업무 툴/스킬)'} />
-          <TextareaBox text={'프로젝트 소개글'} />
-          <DetailBox text={'프로젝트 설명'} />
+          <TextBox text={'제목'} {...title} />
+          <ImgBox text={'대표 사진'} img={img} selectFile={selectFile} />
+          <TextBox text={'깃허브 링크'} {...gitLink} />
+          <TextBox text={'배포 링크'} {...distributionLink} />
+          <TagBox
+            text={'기술스택(업무 툴/스킬)'}
+            tags={tags}
+            addTags={addTags}
+            removeTags={removeTags}
+          />
+          <TextareaBox text={'프로젝트 소개글'} {...description} />
+          <DetailBox text={'프로젝트 설명'} content={content} setContent={setContent} />
           <S.ButtonContainer>
-            <S.PrevBtn>이전 페이지</S.PrevBtn>
+            <S.PrevBtn onClick={backTo}>이전 페이지</S.PrevBtn>
             <S.SubmitBtn>수정 하기</S.SubmitBtn>
           </S.ButtonContainer>
         </>
       ) : (
         <>
           <UserBox />
-          <TextBox text={'제목'} />
-          <ImgBox text={'대표 사진'} />
-          <TextBox text={'깃허브 링크'} />
-          <TextBox text={'배포 링크'} />
-          <TagBox text={'기술스택(업무 툴/스킬)'} />
-          <TextareaBox text={'프로젝트 소개글'} />
-          <DetailBox text={'프로젝트 설명'} />
+          <TextBox text={'제목'} {...title} />
+          <ImgBox text={'대표 사진'} img={img} selectFile={selectFile} />
+          <TextBox text={'깃허브 링크'} {...gitLink} />
+          <TextBox text={'배포 링크'} {...distributionLink} />
+          <TagBox
+            text={'기술스택(업무 툴/스킬)'}
+            tags={tags}
+            addTags={addTags}
+            removeTags={removeTags}
+          />
+          <TextareaBox text={'프로젝트 소개글'} {...description} />
+          <DetailBox text={'프로젝트 설명'} content={content} setContent={setContent} />
           <S.ButtonContainer>
-            <S.PrevBtn>이전 페이지</S.PrevBtn>
-            <S.SubmitBtn>작성 하기</S.SubmitBtn>
+            <S.PrevBtn onClick={backTo}>이전 페이지</S.PrevBtn>
+            <S.SubmitBtn onClick={postPortFolio}>작성 하기</S.SubmitBtn>
           </S.ButtonContainer>
         </>
       )}

--- a/client/src/components/Portfolio/TagBox.tsx
+++ b/client/src/components/Portfolio/TagBox.tsx
@@ -5,24 +5,12 @@ import { TiDeleteOutline } from 'react-icons/ti';
 
 type TagBoxProps = {
   text: string;
+  tags: string[];
+  addTags: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  removeTags: (indexToRemove: number) => void;
 };
 
-const TagBox: React.FC<TagBoxProps> = ({ text }) => {
-  const [tags, setTags] = useState([] as any);
-  const removeTags = (indexToRemove: number) => {
-    setTags(tags.filter((it: string, index: number) => index !== indexToRemove));
-  };
-
-  const addTags = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const tag = event.currentTarget.value;
-    if (tags.includes(tag) || tag.length === 0) {
-      console.log('Fail!');
-      return;
-    }
-    event.currentTarget.value = '';
-    setTags([...tags, tag]);
-  };
-
+const TagBox: React.FC<TagBoxProps> = ({ text, tags, addTags, removeTags }) => {
   return (
     <S.TagContainer>
       <S.Title>{text}</S.Title>

--- a/client/src/components/Portfolio/TextBox.tsx
+++ b/client/src/components/Portfolio/TextBox.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import * as S from './TextBox.style';
 type TextBoxProps = {
   text: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
 };
 
-const TextBox: React.FC<TextBoxProps> = ({ text }) => {
+const TextBox: React.FC<TextBoxProps> = ({ text, onChange, value }) => {
   return (
     <S.TextContainer>
       <S.Title>{text}</S.Title>
-      <S.InputBox placeholder={text + '을(를) 입력해주세요'}></S.InputBox>
+      <S.InputBox
+        placeholder={text + '을(를) 입력해주세요'}
+        onChange={onChange}
+        value={value}
+      ></S.InputBox>
     </S.TextContainer>
   );
 };

--- a/client/src/components/Portfolio/TextareaBox.tsx
+++ b/client/src/components/Portfolio/TextareaBox.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 import * as S from './TextareaBox.style';
 type TextareaBoxProps = {
   text: string;
+  onChange: (e: any) => void;
+  value: string;
 };
 
-const TextareaBox: React.FC<TextareaBoxProps> = ({ text }) => {
+const TextareaBox: React.FC<TextareaBoxProps> = ({ text, onChange, value }) => {
   return (
     <S.TextareaContainer>
       <S.Title>{text}</S.Title>
-      <S.TextareaBox placeholder={text + '을(를) 입력해주세요(60자 이내)'} maxLength={60} />
+      <S.TextareaBox
+        placeholder={text + '을(를) 입력해주세요(60자 이내)'}
+        onChange={onChange}
+        maxLength={60}
+        value={value}
+      />
     </S.TextareaContainer>
   );
 };

--- a/client/src/hooks/useInput.ts
+++ b/client/src/hooks/useInput.ts
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+
+const useInput = (initialValue: string) => {
+  const [value, setValue] = useState<string>(initialValue);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return {
+    value,
+    onChange: handleChange,
+    setValue,
+  };
+};
+
+export default useInput;

--- a/client/src/hooks/useRouter.ts
+++ b/client/src/hooks/useRouter.ts
@@ -1,10 +1,11 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
 
 export const useRouter = () => {
-  const router = useNavigate()
+  const router = useNavigate();
 
   return {
     currentPath: window.location.pathname,
     routeTo: (path: string) => router(path),
-  }
-}
+    backTo: () => router(-1),
+  };
+};

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -69,7 +69,7 @@ const routerData: RouterElement[] = [
   },
   {
     id: 6,
-    path: '/EditPortfolio',
+    path: '/EditPortfolio/:id',
     label: 'EditPortfolio',
     element: <EditPortfolio />,
     withAuth: true,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -15,6 +15,17 @@ export type GetUserProfile = {
 };
 
 // Portfolio
+export type PostPortfolio = {
+  userId: number;
+  title: string;
+  img: File;
+  gitLink: string;
+  distributionLink: string;
+  description: string;
+  tags: string[];
+  content: string;
+};
+
 export type GetPortfolio = {
   portfolioId: number;
   userId: number;


### PR DESCRIPTION
### Branch
fe-feat/포트폴리오 작성페이지/#63 => fe

### 참고 사항
- useInput 훅 생성 및 포트폴리오 상태 관리에 적용
- react quill 내부의 사진 src를 url로 받아오는 기능 추가(이미지 크기 조정 기능은 수정 필요)
- form 형태로 axios 전송 기능 구현 (backend와 논의 및 react query로 수정 필요)
- PostPortfolio 타입 지정
- EditPortfolio 라우터 경로에 id 추가
