### PR TITLE
feat:포트폴리오 생성, 수정 페이지 AJAX 구현 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,8 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
+        "@xeger/quill-image-actions": "^0.7.1",
+        "@xeger/quill-image-formats": "^0.7.1",
         "axios": "^1.4.0",
         "highlight.js": "^11.8.0",
         "jwt-decode": "^3.1.2",
@@ -4603,6 +4605,29 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.5",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xeger/quill-image-actions": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@xeger/quill-image-actions/-/quill-image-actions-0.7.1.tgz",
+      "integrity": "sha512-3Hi61NhvCzfj1QUpAGHJqfc5rLgljC/jum1qe8+ZjIVP4tICTLUxBwXu4jnTH53zT1ztiWZrfyscxrP2LsxMcg==",
+      "dependencies": {
+        "core-js": "^3.0",
+        "deepmerge": "^4.2"
+      },
+      "peerDependencies": {
+        "quill": "^1.3.6"
+      }
+    },
+    "node_modules/@xeger/quill-image-formats": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@xeger/quill-image-formats/-/quill-image-formats-0.7.1.tgz",
+      "integrity": "sha512-YY3aHDHslByYrGqxR1emeL1G4VjmmosTIEOO2tvp8+z4c3TFcXZqy7t1vGQe8koksb9WurmmtSrHWLhDQTmKaA==",
+      "dependencies": {
+        "core-js": "^3.0"
+      },
+      "peerDependencies": {
+        "quill": "^1.3.6"
       }
     },
     "node_modules/@xtuc/ieee754": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
     "@types/node": "^16.18.25",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
+    "@xeger/quill-image-actions": "^0.7.1",
+    "@xeger/quill-image-formats": "^0.7.1",
     "axios": "^1.4.0",
     "highlight.js": "^11.8.0",
     "quill-image-resize-module-ts": "^3.0.3",

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -15,6 +15,8 @@ import {
   GetUserComment,
   PatchUserProfile,
   DeletePortfolioComment,
+  PostPortfolio,
+  PatchPortfolio,
 } from '../types/index';
 
 const REFRESH_URL = ''; // refresh URL을 새롭게 추가를 해야 한다.
@@ -90,6 +92,52 @@ export const PortfolioAPI = {
       `${process.env.REACT_APP_API_URL}/portfolios/${portfolioId}`,
     );
     return PortfolioData.data.data;
+  },
+  postPortfolio: async (Portfolio: PostPortfolio): Promise<GetPortfolio> => {
+    const { postDto, representativeImg, images, files } = Portfolio;
+
+    // 폼 데이터 형식 사용
+    const formData = new FormData();
+
+    const Dto = new Blob([JSON.stringify(postDto)], {
+      type: 'application/json',
+    });
+
+    formData.append('postDto', Dto);
+    if (representativeImg) formData.append('representativeImg', representativeImg);
+    if (images) formData.append('images', images);
+    if (files) formData.append('files', files);
+
+    return await tokenClient.post(`${process.env.REACT_APP_API_URL}/portfolios`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
+  patchPortfolio: async (Portfolio: PatchPortfolio): Promise<GetPortfolio> => {
+    const { portfolioId, postDto, representativeImg, images, files } = Portfolio;
+
+    // 폼 데이터 형식 사용
+    const formData = new FormData();
+
+    const Dto = new Blob([JSON.stringify(postDto)], {
+      type: 'application/json',
+    });
+
+    formData.append('patchDto', Dto);
+    if (representativeImg) formData.append('representativeImg', representativeImg);
+    if (images) formData.append('images', images);
+    if (files) formData.append('files', files);
+
+    return await tokenClient.patch(
+      `${process.env.REACT_APP_API_URL}/portfolios/${portfolioId}`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
   },
 };
 

--- a/client/src/components/Portfolio/DetailBox.style.ts
+++ b/client/src/components/Portfolio/DetailBox.style.ts
@@ -7,6 +7,7 @@ export const DetailContainer = styled.div`
 
   .ql-container {
     background-color: ${(props) => props.theme.themeStyle.inputColor};
+    min-height: 15rem;
   }
 `;
 export const Title = styled.span`

--- a/client/src/components/Portfolio/DetailBox.style.ts
+++ b/client/src/components/Portfolio/DetailBox.style.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
+import { COLOR } from '../../constants';
 
+const { mainColor } = COLOR;
 export const DetailContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -8,6 +10,9 @@ export const DetailContainer = styled.div`
   .ql-container {
     background-color: ${(props) => props.theme.themeStyle.inputColor};
     min-height: 15rem;
+  }
+  .ql-toolbar {
+    background-color: ${mainColor};
   }
 `;
 export const Title = styled.span`

--- a/client/src/components/Portfolio/DetailBox.tsx
+++ b/client/src/components/Portfolio/DetailBox.tsx
@@ -103,10 +103,10 @@ const DetailBox: React.FC<DetailBoxProps> = ({ text, content, setContent }) => {
           ['clean'],
         ],
 
-        // 내부 이미지를 url로 받아오는 handler
-        handlers: {
-          image: imageHandler,
-        },
+        // // 내부 이미지를 url로 받아오는 handler
+        // handlers: {
+        //   image: imageHandler,
+        // },
       },
     };
   }, []);

--- a/client/src/components/Portfolio/DetailBox.tsx
+++ b/client/src/components/Portfolio/DetailBox.tsx
@@ -7,10 +7,12 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import c from 'highlight.js/lib/languages/c';
 import ReactQuill, { Quill } from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
-import { ImageResize } from 'quill-image-resize-module-ts';
 import axios from 'axios';
+import { ImageActions } from '@xeger/quill-image-actions';
+import { ImageFormats } from '@xeger/quill-image-formats';
 
-Quill.register('modules/ImageResize', ImageResize);
+Quill.register('modules/imageActions', ImageActions);
+Quill.register('modules/imageFormats', ImageFormats);
 
 type DetailBoxProps = {
   text: string;
@@ -54,54 +56,67 @@ const DetailBox: React.FC<DetailBoxProps> = ({ text, content, setContent }) => {
     };
   };
 
+  const formats = [
+    'align',
+    'background',
+    'blockquote',
+    'bold',
+    'code-block',
+    'color',
+    'float',
+    'font',
+    'header',
+    'height',
+    'image',
+    'italic',
+    'link',
+    'script',
+    'strike',
+    'size',
+    'underline',
+    'width',
+    'image',
+  ];
+
   const modules = useMemo(() => {
     return {
-      // syntax: {
-      //   highlight: (text: any) => hljs.highlightAuto(text).value,
-      // },
+      imageActions: {},
+      imageFormats: {},
       toolbar: {
         container: [
-          [{ header: [1, 2, false] }, { header: '2' }, { font: [String] }],
-          [{ size: [String] }],
-          ['bold', 'italic', 'underline', 'strike', 'blockquote'],
-          [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
-          ['link', 'image', 'code-block'],
+          ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+          ['blockquote', 'image', 'code-block'],
+
+          [{ header: 1 }, { header: 2 }], // custom button values
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          [{ script: 'sub' }, { script: 'super' }], // superscript/subscript
+          [{ indent: '-1' }, { indent: '+1' }], // outdent/indent
+          [{ direction: 'rtl' }], // text direction
+
+          [{ size: ['small', false, 'large', 'huge'] }], // custom dropdown
+          [{ header: [1, 2, 3, 4, 5, 6, false] }],
+
+          [{ color: [] }, { background: [] }], // dropdown with defaults from theme
+          [{ font: [] }],
+          [{ align: [] }],
+
           ['clean'],
         ],
-        // handlers: {
-        //   image: imageHandler,
-        // },
-      },
-      // 이미지 조절 시 오류
-      ImageResize: {
-        modules: ['Resize', 'DisplaySize', 'Toolbar'],
+
+        // 내부 이미지를 url로 받아오는 handler
+        handlers: {
+          image: imageHandler,
+        },
       },
     };
   }, []);
-
-  const formats = [
-    'header',
-    'font',
-    'size',
-    'bold',
-    'italic',
-    'underline',
-    'strike',
-    'blockquote',
-    'list',
-    'bullet',
-    'indent',
-    'link',
-    'image',
-    'video',
-    'code-block',
-  ];
 
   return (
     <S.DetailContainer>
       <S.Title>{text}</S.Title>
       <ReactQuill
         ref={quillRef}
+        formats={formats}
         modules={modules}
         onChange={setContent}
         value={content}

--- a/client/src/components/Portfolio/DetailBox.tsx
+++ b/client/src/components/Portfolio/DetailBox.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as S from './DetailBox.style';
-import hljs from 'highlight.js/lib/core';
-import javascript from 'highlight.js/lib/languages/javascript';
-import python from 'highlight.js/lib/languages/python';
-import typescript from 'highlight.js/lib/languages/typescript';
-import c from 'highlight.js/lib/languages/c';
+
+import hljs from 'highlight.js';
+import 'highlight.js/styles/rainbow.css';
+
 import ReactQuill, { Quill } from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import axios from 'axios';
@@ -20,10 +19,9 @@ type DetailBoxProps = {
   setContent: React.Dispatch<React.SetStateAction<string>>;
 };
 
-hljs.registerLanguage('javascript', javascript);
-hljs.registerLanguage('python', python);
-hljs.registerLanguage('typescript', typescript);
-hljs.registerLanguage('c', c);
+hljs.configure({
+  languages: ['javascript', 'ruby', 'python', 'java', 'cpp', 'kotlin', 'sql'],
+});
 
 const DetailBox: React.FC<DetailBoxProps> = ({ text, content, setContent }) => {
   const quillRef = useRef<ReactQuill | null>(null);
@@ -82,6 +80,9 @@ const DetailBox: React.FC<DetailBoxProps> = ({ text, content, setContent }) => {
     return {
       imageActions: {},
       imageFormats: {},
+      syntax: {
+        highlight: (text: any) => hljs.highlightAuto(text).value,
+      },
       toolbar: {
         container: [
           ['bold', 'italic', 'underline', 'strike'], // toggled buttons

--- a/client/src/components/Portfolio/ImgBox.tsx
+++ b/client/src/components/Portfolio/ImgBox.tsx
@@ -1,19 +1,22 @@
-import React, { useState } from 'react';
+import React from 'react';
 import * as S from './ImgBox.style';
 
 type ImgBoxProps = {
   text: string;
   img: File | null;
   selectFile: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  representativeImgUrl: string | null;
 };
 
-const ImgBox: React.FC<ImgBoxProps> = ({ text, img, selectFile }) => {
+const ImgBox: React.FC<ImgBoxProps> = ({ text, img, selectFile, representativeImgUrl }) => {
   return (
     <S.ImgContainer>
       <S.Title>{text}</S.Title>
       <S.ImgSelector>
         {img ? (
           <S.ImgName>{img.name}</S.ImgName>
+        ) : representativeImgUrl ? (
+          <S.ImgName>{representativeImgUrl}</S.ImgName>
         ) : (
           <S.ImgName className='gray-font'>{'사진을 선택해주세요'}</S.ImgName>
         )}

--- a/client/src/components/Portfolio/PortfolioContainer.tsx
+++ b/client/src/components/Portfolio/PortfolioContainer.tsx
@@ -1,45 +1,106 @@
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import * as S from './PortfolioContainer.style';
+
+// react hooks
+import React, { useEffect, useState } from 'react';
+
+// react component
 import TextBox from './TextBox';
 import ImgBox from './ImgBox';
 import TagBox from './TagBox';
 import TextareaBox from './TextareaBox';
 import DetailBox from './DetailBox';
 import UserBox from './UserBox';
-import useInput from '../../hooks/useInput';
+
+// react-router-dom
+import { useParams } from 'react-router-dom';
+
+// custom hooks
 import { useRouter } from '../../hooks/useRouter';
+import { usePostPortfolio } from '../../hooks/usePostPortfolio';
+import { usePatchPortfolio } from '../../hooks/usePatchPortfolio';
+
+// types
+import { postDto, GetPortfolio, GetUserProfile } from '../../types';
 
 type PortfolioContainerProps = {
   isEdit: boolean;
+  UserInfo: GetUserProfile;
+  PortfolioInfo?: GetPortfolio;
 };
 
-const PortfolioContainer: React.FC<PortfolioContainerProps> = ({ isEdit }) => {
-  const { routeTo, backTo } = useRouter();
+const PortfolioContainer: React.FC<PortfolioContainerProps> = ({
+  isEdit,
+  UserInfo,
+  PortfolioInfo,
+}) => {
+  const { backTo } = useRouter();
+
+  // portfolioId 받기
+  const { portfolioId } = useParams();
+
+  // 유저 정보 받기
+  const userId: number | null = UserInfo ? UserInfo.userId : null;
+  const email: string = UserInfo ? UserInfo.email : '';
+  const profileImg: string = UserInfo ? UserInfo.profileImg : '';
+
   const setting =
     '<p><br></p><h3><strong>*본 형식은 작성을 돕는 가이드일 뿐입니다, 자유로운 형식으로 작성해보세요*</strong></h3><p><br></p><h3>기간 : 2023.00.00 - 2023.00.00</h3><p><br></p><h3>Overview ｜ 프로젝트 요약</h3><p>본인이 진행한 프로젝트에서 어떤 일을 진행했는지 알 수 있도록 간결하게 설명해주세요</p><p><br></p><h3>Role ｜ 역할</h3><p>해당 프로젝트에서 본인이 기여한 정도와 역할을 작성해 주세요.</p><p>기여도 : 00%</p><p><br></p><h3>Function ｜ 기능</h3><p> 작동 화면과 간단한 설명으로 프로젝트에서 구현한 기능에 대해서 설명해주세요.</p><p><br></p><p><br></p><h3>Result ｜ 성과</h3><p>해당 프로젝트의 성과를 작성해 주세요. 수치, 숫자로 성과를 표현할 수 있다면 설득력이 높아져요. 수치로 표현하기 어려운 성과라면 정성적인 성과도 괜찮아요.</p><p><br></p><p><br></p><h3>Lesson-Learned ｜ 프로젝트 후 배운 것</h3><p>모든 프로젝트가 성공하지 못했더라도, 배운 점은 있을 거예요. 해당 프로젝트에서 배운 점, 아쉬웠던 점, 개선할 수 있는 점을 적어서 다음 프로젝트 진행 시에 이를 보완할 수 있다는 것을 어필해 보세요.</p>';
-  // 포트폴리오 정보
-  const title = useInput('');
-  const [img, setImg] = useState<File | null>(null);
-  const gitLink = useInput('');
-  const distributionLink = useInput('');
-  const [tags, setTags] = useState<string[]>([]);
-  const description = useInput('');
-  const [content, setContent] = useState(setting);
 
-  // tag 조작 함수
-  const removeTags = (indexToRemove: number) => {
-    setTags(tags.filter((it: string, index: number) => index !== indexToRemove));
+  // 포트폴리오 정보
+  const [portfolio, setPortfolio] = useState<postDto>({
+    userId: Number(userId),
+    title: '',
+    gitLink: '',
+    distributionLink: '',
+    description: '',
+    content: setting,
+    skills: [],
+  });
+
+  // 전송 시 대표 이미지 파일
+  const [img, setImg] = useState<File | null>(null);
+
+  // 수신 시 대표 이미지 파일 url
+  const representativeImgUrl = PortfolioInfo ? PortfolioInfo.representativeImgUrl : null;
+
+  // const imgUrl = PortfolioInfo ? PortfolioInfo.imgUrl : '';
+  // const fileUrl = PortfolioInfo ? PortfolioInfo.fileUrl : '';
+
+  // input,textinput 값에 대한 변경
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    setPortfolio({ ...portfolio, [name]: value });
   };
 
+  // tag 제거 함수
+  const removeTags = (indexToRemove: number) => {
+    setPortfolio({
+      ...portfolio,
+      skills: portfolio.skills.filter((it: string, index: number) => index !== indexToRemove),
+    });
+  };
+
+  // tag 추가 함수
   const addTags = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const tag = event.currentTarget.value;
-    if (tags.includes(tag) || tag.length === 0) {
+    const skill = event.currentTarget.value;
+
+    if (portfolio.skills.includes(skill) || skill.length === 0) {
       console.log('Fail!');
       return;
     }
     event.currentTarget.value = '';
-    setTags([...tags, tag]);
+    setPortfolio({
+      ...portfolio,
+      skills: [...portfolio.skills, skill],
+    });
+  };
+
+  // content 조작 함수
+  const handleContent = (e: any) => {
+    // console.log(e);
+    setPortfolio({ ...portfolio, content: e });
   };
 
   // 파일 선택 함수
@@ -49,96 +110,102 @@ const PortfolioContainer: React.FC<PortfolioContainerProps> = ({ isEdit }) => {
       const reader = new FileReader();
       reader.readAsDataURL(file);
       setImg(file);
+      // console.log(file);
     }
   };
 
-  const postPortFolio = async () => {
-    // form 형태로 전달
-    const body = new FormData();
-    const data = {
-      // id: String(Math.floor(Math.random() * 10000)),
-      userId: 1,
-      title: title.value,
-      // img: img,
-      gitLink: gitLink.value,
-      distributionLink: distributionLink.value,
-      // tags: tags,
-      description: description.value,
-      content,
-    };
-
-    console.log(JSON.stringify(data));
-    // blob 형태로 변환 후 form에 추가
-    const blob = new Blob([JSON.stringify(data)], {
-      type: 'application/json',
-    });
-    body.append('portfolio', blob);
-
-    // blob에서 정보 받아오기
-    const text = await new Response(blob).text();
-    // console.log(JSON.parse(text));
-
-    const res = await axios.post('http://43.201.157.191:8080/portfolios', data, {
-      // headers: {
-      //   'Content-Type': 'multipart/form-data',
-      // },
-    });
-  };
-
-  const getPortFolio = async () => {
-    const { data } = await axios.get('http://43.201.157.191:8080/portfolios/1');
-    const portfolio = data;
-  };
+  // mutation을 이용한 서버 요청
+  const { handlePatch } = usePatchPortfolio();
+  const { handlePost } = usePostPortfolio();
 
   useEffect(() => {
-    if (isEdit) {
-      getPortFolio();
+    // portfolio 초기값 설정
+    if (PortfolioInfo) {
+      const { userId, title, gitLink, distributionLink, description, content, skills } =
+        PortfolioInfo;
+      const data: postDto = {
+        userId,
+        title,
+        gitLink,
+        distributionLink,
+        description,
+        content,
+        skills,
+      };
+      setPortfolio(data);
     }
   }, [isEdit]);
 
   return (
     <S.PortfolioLayout>
-      {isEdit ? (
-        <>
-          <UserBox />
-          <TextBox text={'제목'} {...title} />
-          <ImgBox text={'대표 사진'} img={img} selectFile={selectFile} />
-          <TextBox text={'깃허브 링크'} {...gitLink} />
-          <TextBox text={'배포 링크'} {...distributionLink} />
-          <TagBox
-            text={'기술스택(업무 툴/스킬)'}
-            tags={tags}
-            addTags={addTags}
-            removeTags={removeTags}
-          />
-          <TextareaBox text={'프로젝트 소개글'} {...description} />
-          <DetailBox text={'프로젝트 설명'} content={content} setContent={setContent} />
-          <S.ButtonContainer>
-            <S.PrevBtn onClick={backTo}>이전 페이지</S.PrevBtn>
-            <S.SubmitBtn>수정 하기</S.SubmitBtn>
-          </S.ButtonContainer>
-        </>
-      ) : (
-        <>
-          <UserBox />
-          <TextBox text={'제목'} {...title} />
-          <ImgBox text={'대표 사진'} img={img} selectFile={selectFile} />
-          <TextBox text={'깃허브 링크'} {...gitLink} />
-          <TextBox text={'배포 링크'} {...distributionLink} />
-          <TagBox
-            text={'기술스택(업무 툴/스킬)'}
-            tags={tags}
-            addTags={addTags}
-            removeTags={removeTags}
-          />
-          <TextareaBox text={'프로젝트 소개글'} {...description} />
-          <DetailBox text={'프로젝트 설명'} content={content} setContent={setContent} />
-          <S.ButtonContainer>
-            <S.PrevBtn onClick={backTo}>이전 페이지</S.PrevBtn>
-            <S.SubmitBtn onClick={postPortFolio}>작성 하기</S.SubmitBtn>
-          </S.ButtonContainer>
-        </>
-      )}
+      <UserBox email={email} profileImg={profileImg} />
+      <TextBox text={'제목'} value={portfolio.title} name={'title'} onChange={handleInputChange} />
+      <ImgBox
+        text={'대표 사진'}
+        img={img}
+        selectFile={selectFile}
+        representativeImgUrl={representativeImgUrl}
+      />
+      <TextBox
+        text={'깃허브 링크'}
+        value={portfolio.gitLink}
+        name={'gitLink'}
+        onChange={handleInputChange}
+      />
+      <TextBox
+        text={'배포 링크'}
+        value={portfolio.distributionLink}
+        name={'distributionLink'}
+        onChange={handleInputChange}
+      />
+      <TagBox
+        text={'기술스택(업무 툴/스킬)'}
+        tags={portfolio.skills}
+        addTags={addTags}
+        removeTags={removeTags}
+      />
+      <TextareaBox
+        text={'프로젝트 소개글'}
+        value={portfolio.description}
+        name={'description'}
+        onChange={handleInputChange}
+      />
+      <DetailBox text={'프로젝트 설명'} content={portfolio.content} setContent={handleContent} />
+      <S.ButtonContainer>
+        <S.PrevBtn onClick={backTo}>이전 페이지</S.PrevBtn>
+
+        {
+          // isEdit에 따라 버튼 결정
+          isEdit ? (
+            <S.SubmitBtn
+              onClick={() =>
+                handlePatch({
+                  portfolioId: Number(portfolioId),
+                  postDto: {
+                    ...portfolio,
+                  },
+                  representativeImg: img,
+                })
+              }
+            >
+              수정 하기
+            </S.SubmitBtn>
+          ) : (
+            <S.SubmitBtn
+              onClick={() =>
+                handlePost({
+                  postDto: {
+                    ...portfolio,
+                  },
+                  representativeImg: img,
+                })
+              }
+            >
+              작성 하기
+            </S.SubmitBtn>
+          )
+        }
+      </S.ButtonContainer>
     </S.PortfolioLayout>
   );
 };

--- a/client/src/components/Portfolio/TextBox.tsx
+++ b/client/src/components/Portfolio/TextBox.tsx
@@ -4,13 +4,15 @@ type TextBoxProps = {
   text: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   value?: string;
+  name?: string;
 };
 
-const TextBox: React.FC<TextBoxProps> = ({ text, onChange, value }) => {
+const TextBox: React.FC<TextBoxProps> = ({ text, onChange, value, name }) => {
   return (
     <S.TextContainer>
       <S.Title>{text}</S.Title>
       <S.InputBox
+        name={name}
         placeholder={text + '을(를) 입력해주세요'}
         onChange={onChange}
         value={value}

--- a/client/src/components/Portfolio/TextareaBox.tsx
+++ b/client/src/components/Portfolio/TextareaBox.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import * as S from './TextareaBox.style';
 type TextareaBoxProps = {
   text: string;
-  onChange: (e: any) => void;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   value: string;
+  name?: string;
 };
 
-const TextareaBox: React.FC<TextareaBoxProps> = ({ text, onChange, value }) => {
+const TextareaBox: React.FC<TextareaBoxProps> = ({ text, onChange, value, name }) => {
   return (
     <S.TextareaContainer>
       <S.Title>{text}</S.Title>
       <S.TextareaBox
         placeholder={text + '을(를) 입력해주세요(60자 이내)'}
+        name={name}
         onChange={onChange}
         maxLength={60}
         value={value}

--- a/client/src/components/Portfolio/UserBox.tsx
+++ b/client/src/components/Portfolio/UserBox.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import * as S from '../Portfolio/UserBox.style';
-function UserBox() {
-  const img =
-    'https://images.unsplash.com/photo-1488161628813-04466f872be2?crop=entropy&cs=srgb&fm=jpg&ixid=Mnw3MjAxN3wwfDF8c2VhcmNofDl8fHBlb3BsZXxlbnwwfHx8fDE2ODMwODA2MDQ&ixlib=rb-4.0.3&q=85&q=85&fmt=jpg&crop=entropy&cs=tinysrgb&w=450';
+
+type UserBoxProps = {
+  email: string;
+  profileImg: string;
+};
+
+const UserBox: React.FC<UserBoxProps> = ({ email, profileImg }) => {
+  // const img =
+  //   'https://images.unsplash.com/photo-1488161628813-04466f872be2?crop=entropy&cs=srgb&fm=jpg&ixid=Mnw3MjAxN3wwfDF8c2VhcmNofDl8fHBlb3BsZXxlbnwwfHx8fDE2ODMwODA2MDQ&ixlib=rb-4.0.3&q=85&q=85&fmt=jpg&crop=entropy&cs=tinysrgb&w=450';
+  console.log(profileImg);
   return (
     <S.UserBox>
       <S.UserImg>
-        <img src={img} />
+        <img src={profileImg} />
       </S.UserImg>
-      <span>kimcoding</span>
+      <span>{email}</span>
     </S.UserBox>
   );
-}
+};
 
 export default UserBox;

--- a/client/src/hooks/usePatchPortfolio.ts
+++ b/client/src/hooks/usePatchPortfolio.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { PatchPortfolio } from '../types/index';
+import { PortfolioAPI } from '../api/client';
+
+const { patchPortfolio } = PortfolioAPI;
+
+export const usePatchPortfolio = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate: patchPortfolioMutation } = useMutation(patchPortfolio, {
+    onMutate: (variable) => {
+      // ! invalidateQuerie 추가 여부 결정
+      console.log('onMutate', variable);
+    },
+    onError: (error, variable, context) => {
+      console.log(error);
+    },
+    onSuccess: (data, variables, context) => {
+      console.log('success', data, variables, context);
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+
+  const handlePatch = async (Portfolio: PatchPortfolio) => {
+    patchPortfolioMutation(Portfolio);
+  };
+
+  return { patchPortfolioMutation, handlePatch };
+};

--- a/client/src/hooks/usePostPortfolio.ts
+++ b/client/src/hooks/usePostPortfolio.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { PostPortfolio } from '../types/index';
+import { PortfolioAPI } from '../api/client';
+
+const { postPortfolio } = PortfolioAPI;
+
+export const usePostPortfolio = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate: postPortfolioMutation } = useMutation(postPortfolio, {
+    onMutate: (variable) => {
+      // ! invalidateQuerie 추가 여부 결정
+      console.log('onMutate', variable);
+    },
+    onError: (error, variable, context) => {
+      console.log(error);
+    },
+    onSuccess: (data, variables, context) => {
+      console.log('success', data, variables, context);
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+
+  const handlePost = async (Portfolio: PostPortfolio) => {
+    postPortfolioMutation(Portfolio);
+  };
+  return { postPortfolioMutation, handlePost };
+};

--- a/client/src/pages/EditPortfolio.tsx
+++ b/client/src/pages/EditPortfolio.tsx
@@ -1,11 +1,38 @@
-import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Loading from '../components/common/Loading';
 import PortfolioContainer from '../components/Portfolio/PortfolioContainer';
+import { useGetPortfolio } from '../hooks/useGetPortfolio';
 import * as S from './EditPortfolio.style';
 
+import { getUserIdFromAccessToken } from '../utils/getUserIdFromAccessToken';
+import { useGetUserProfile } from '../hooks/useGetUserProfile';
+
+// redux
+import { loginState, access } from '../store/slice/loginSlice';
+import store from '../store';
+
 function EditPortfolio() {
+  const { portfolioId } = useParams();
+
+  // PortfolioInfo 받아오기
+  const { PortfolioInfo, getPortfolioLoading } = useGetPortfolio(Number(portfolioId));
+
+  const isLogin = loginState(store.getState());
+  const accessToken = localStorage.getItem('accessToken');
+  // const accessToken = access(store.getState());
+
+  // userId 받아오기
+  const userId = getUserIdFromAccessToken(isLogin, accessToken);
+
+  // UserInfo 받아오기
+  const { UserInfo, getUserInfoLoading } = useGetUserProfile(Number(userId));
+
   return (
     <S.EditPortfolioContainer>
-      <PortfolioContainer isEdit={true} />
+      {(getPortfolioLoading || getUserInfoLoading) && <Loading />}
+      {PortfolioInfo && UserInfo && (
+        <PortfolioContainer isEdit={true} PortfolioInfo={PortfolioInfo} UserInfo={UserInfo} />
+      )}
     </S.EditPortfolioContainer>
   );
 }

--- a/client/src/pages/NewPortfolio.tsx
+++ b/client/src/pages/NewPortfolio.tsx
@@ -1,11 +1,29 @@
-import React, { useState } from 'react';
 import PortfolioContainer from '../components/Portfolio/PortfolioContainer';
 import * as S from './NewPortfolio.style';
 
+import { getUserIdFromAccessToken } from '../utils/getUserIdFromAccessToken';
+import { useGetUserProfile } from '../hooks/useGetUserProfile';
+
+// redux
+import { loginState, access } from '../store/slice/loginSlice';
+import store from '../store';
+import Loading from '../components/common/Loading';
+
 function NewPortfolio() {
+  const isLogin = loginState(store.getState());
+  const accessToken = localStorage.getItem('accessToken');
+  // const accessToken = access(store.getState());
+
+  // userId 받아오기
+  const userId = getUserIdFromAccessToken(isLogin, accessToken);
+
+  // UserInfo 받아오기
+  const { UserInfo, getUserInfoLoading } = useGetUserProfile(Number(userId));
+
   return (
     <S.NewPortfolioContainer>
-      <PortfolioContainer isEdit={false} />
+      {getUserInfoLoading && <Loading />}
+      {UserInfo && <PortfolioContainer isEdit={false} UserInfo={UserInfo} />}
     </S.NewPortfolioContainer>
   );
 }

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -69,7 +69,7 @@ const routerData: RouterElement[] = [
   },
   {
     id: 6,
-    path: '/EditPortfolio/:id',
+    path: '/EditPortfolio/:portfolioId',
     label: 'EditPortfolio',
     element: <EditPortfolio />,
     withAuth: true,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -50,15 +50,30 @@ export type PatchUserProfile = {
 };
 
 // Portfolio
-export type PostPortfolio = {
+
+export type postDto = {
   userId: number;
   title: string;
-  img: File;
   gitLink: string;
   distributionLink: string;
   description: string;
-  tags: string[];
   content: string;
+  skills: string[];
+};
+
+export type PostPortfolio = {
+  postDto: postDto;
+  representativeImg: File | null;
+  images?: File;
+  files?: File;
+};
+
+export type PatchPortfolio = {
+  portfolioId: number;
+  postDto: postDto;
+  representativeImg: File | null;
+  images?: File;
+  files?: File;
 };
 
 export type GetPortfolio = {


### PR DESCRIPTION
### Branch
fe-feat/로그인 페이지/https://github.com/codestates-seb/seb43_main_001/issues/63 => fe

### 참고 사항
- react quill 툴바 색상 변경
- react quill 이미지 사이즈 조절, 코드 하이라이팅 기능 구현
- post,patchPotfolio API 구현 및 mutation 커스텀 훅 생성
- PortfolioContainer의 portfolio 상태관리 리팩토링 완료
- 포트폴리오 전송, 수정 시 content가 길어지면 오류가 발생하는 문제 해결 필요
