### PR TITLE
feat: UserProfile / UserComment CRUD 기능 구현

### DIFF
--- a/client/src/components/User/CommentContainer.tsx
+++ b/client/src/components/User/CommentContainer.tsx
@@ -5,18 +5,7 @@ import { ChangeEvent, useState } from 'react';
 import { useGetUserComments } from '../../hooks/useGetUserComment';
 import { useGetCommentsToPortfolio } from '../../hooks/useGetCommentsToPortfolio';
 import { useGetCommentsToUser } from '../../hooks/useGetCommentsToUser';
-
-export type Comment = {
-  userId: number;
-  writerId: number;
-  writerName: string;
-  content: string;
-  createdAt: string;
-  updatedAt: string;
-  userCommentId?: number;
-  portfolioCommentId?: number;
-  portfolioId?: number;
-};
+import { usePostUserComment } from '../../hooks/usePostUserComment';
 
 type CommentProps = {
   userId: number;
@@ -26,11 +15,13 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
   const [selectComment, setSelectComment] = useState(true);
   const [category, setCategory] = useState(true);
   const [content, setContent] = useState('');
+  const { handlerPostUserComment } = usePostUserComment(userId);
 
   const addHandler = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     // TODO : 데이터 전송
-    // await axios.post(`${url}/comment`, {});
+    handlerPostUserComment(userId, content);
+    setContent('');
   };
   const contentChangeHandler = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setContent(e.target.value);
@@ -42,6 +33,7 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
   const { CommentsToUser } = useGetCommentsToUser(userId);
 
   // ? : 유저 댓글과 포트폴리오 댓글이 남아있는 문제 < ?????
+
   return (
     <S.CommentContainer>
       <S.SelectBtn>
@@ -60,12 +52,13 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
                 {UserComments.length > 0 ? (
                   <>
                     {UserComments.map((ele) => (
-                      <CommentItem key={ele.userCommentId} data={ele} path='comment' />
+                      <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
                     ))}
                   </>
                 ) : (
                   <>
-                  <p></p></>
+                    <p></p>
+                  </>
                 )}
               </>
             )}
@@ -94,14 +87,14 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
             <S.Comments>
               {CommentsToUser &&
                 CommentsToUser?.map((ele) => (
-                  <CommentItem key={ele.userCommentId} data={ele} path='toUser' />
+                  <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
                 ))}
             </S.Comments>
           ) : (
             <S.Comments>
               {CommentsToPortfolio &&
                 CommentsToPortfolio?.map((ele) => (
-                  <CommentItem key={ele.portfolioCommentId} data={ele} path='toPortfolio' />
+                  <CommentItem key={ele.portfolioCommentId} data={ele} path='portfoliocomments' />
                 ))}
             </S.Comments>
           )}

--- a/client/src/components/User/CommentItem.tsx
+++ b/client/src/components/User/CommentItem.tsx
@@ -1,43 +1,58 @@
 import React, { FormEvent, useRef, useState } from 'react';
 import * as S from './CommentItem.style';
-import axios from 'axios';
-import { Comment } from './CommentContainer';
+import { usePatchUserComment } from '../../hooks/usePatchUserComment';
+import { useDeleteComment } from '../../hooks/useDeleteComment';
+import { GetUserComment } from '../../types';
+import { useRouter } from '../../hooks/useRouter';
 
 type CommentItemProps = {
-  data: Comment;
+  data: GetUserComment;
   path: string;
 };
 
-// TODO : 삭제 기능 구현
 const CommentItem: React.FC<CommentItemProps> = ({ data, path }) => {
+  const { routeTo } = useRouter();
   const [onEdit, setOnEdit] = useState<boolean>(false);
   const CommentRef = useRef<HTMLTextAreaElement>(null);
   const [editText, setEditText] = useState<string>(data.content);
+  const { handlePatchUserComment } = usePatchUserComment(data.userId, data.portfolioId!);
+  const { handlerDeleteUserComment } = useDeleteComment(data.userId, data.portfolioId!);
+
+  const date = `${data.createdAt[0]}. ${data.createdAt[1]}. ${data.createdAt[2]}`;
   const onChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setEditText(e.currentTarget.value);
   };
   const onSubmitHandler = async (e: FormEvent) => {
     e.preventDefault();
-    // await axios.post(url, {
-    //   comment: editText,
-    // });
-    await axios.patch(`${process.env.REACT_APP_API_URL}/${path}`, {
-      data: [
-        {
-          ...data,
-          content: editText,
-        },
-      ],
+    handlePatchUserComment({
+      commentId: data.userCommentId ? data.userCommentId : data.portfolioCommentId!,
+      content: editText,
+      userId: data.userId,
+      pathId: data.writerId ? data.writerId : data.portfolioId!,
+      path,
     });
     setOnEdit(false);
   };
-  // const onDeleteHandler = async () => {
-  //   await axios.delete(`${process.env.REACT_APP_API_URL}`)
-  // };
-
+  const deleteHandler = async () => {
+    handlerDeleteUserComment({
+      commentId: data.userCommentId ? data.userCommentId : data.portfolioCommentId!,
+      path,
+    });
+  };
+  const onClickHandler = () => {
+    if (path === 'usercomments') {
+      console.log('?');
+      routeTo(`/User/${data.userId}`);
+    } else {
+      routeTo(`/Detail/${data.portfolioId}`);
+    }
+  };
+  // ! : 로그인한 유저 === 페이지 유저 : 삭제 버튼 보여야 함
+  // ! : 로그인한 유저 === 작성자 : 삭제 & 수정 버튼 보여야 함
+  // ! : Auth 데이터가 어떻게 도착하는지 보고 반영하기
   return (
     <S.CommentItem>
-      <S.DelBtn />
+      <S.DelBtn onClick={deleteHandler} />
       {!onEdit && <S.EditBtn onClick={() => setOnEdit(true)} />}
       {onEdit && <S.SubmitBtn onClick={onSubmitHandler} />}
       {onEdit ? (
@@ -47,12 +62,13 @@ const CommentItem: React.FC<CommentItemProps> = ({ data, path }) => {
       ) : (
         <p>{editText}</p>
       )}
-      {/* 해당 유저/포트폴리오 페이지로 이동 */}
-      {data.userId && !data.portfolioId && <S.LinkIcon />}
-      {data.portfolioId && <S.LinkIcon />}
+      {/* 본인의 페이지 일 때는 표시하지 않기 */}
+      <S.LinkIcon onClick={onClickHandler} />
       <S.CommentUser>
-        <span>{new Date(data.createdAt).toLocaleDateString()}</span>
-        <S.ImgBox>{/* <img src={data.img} /> */}</S.ImgBox>
+        <span>{date}</span>
+        <S.ImgBox>
+          <img src={data.userProfileImg || data.writerProfileImg} />
+        </S.ImgBox>
         <p>{data.writerName}</p>
       </S.CommentUser>
     </S.CommentItem>

--- a/client/src/components/User/UserBasicInfo.style.ts
+++ b/client/src/components/User/UserBasicInfo.style.ts
@@ -75,6 +75,14 @@ export const UserName = styled.p`
 export const GitBtn = styled.button`
   margin-bottom: 3px;
 `;
+export const EditGit = styled.label`
+  input {
+    border: 1px solid;
+    border-radius: 5px;
+    font-size: 1rem;
+  }
+`;
+
 export const Buttons = styled.div`
   display: flex;
   flex-direction: column;

--- a/client/src/components/User/UserBasicInfo.tsx
+++ b/client/src/components/User/UserBasicInfo.tsx
@@ -1,9 +1,10 @@
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { YellowBtn } from '../common/Button.style';
 // import { user } from './mock';
 import * as S from './UserBasicInfo.style';
-import { setImg, setName } from '../../store/slice/editUserProfileSlice';
+import { setGit, setImg, setName } from '../../store/slice/editUserProfileSlice';
 import { useState } from 'react';
+import { RootState } from '../../store';
 
 type UserBasicInfoProps = {
   onEdit: boolean;
@@ -19,9 +20,16 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
   gitLink,
   auth,
 }) => {
+  const dispatch = useDispatch();
+  const userEditInfo = useSelector((state: RootState) => {
+    return state.editUserProfile;
+  });
+  const { gitLink: editGitLink } = userEditInfo;
   const [photo, setPhoto] = useState<string>(profileImg);
   const [userName, setUserName] = useState<string>(name);
-  const dispatch = useDispatch();
+  // ! : input에 null값을 넣지 않기 위해 editSlice의 정보 사용,(서버에서 처리해주면 기존값 사용해도 괜찮음)
+  const [userGit, setUserGit] = useState<string>(editGitLink);
+
   const fileUploadHanlder = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.currentTarget;
     const files = (target.files as FileList)[0];
@@ -31,15 +39,20 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
       setPhoto(reader.result as string);
     };
     reader.readAsDataURL(files);
-
-    // ! : axios를 통해서 전달하는 부분은 file
     dispatch(setImg({ ...files }));
   };
-  const nameHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.value;
-    setUserName(value);
-    dispatch(setName(value));
+
+  const inputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value, name } = e.currentTarget;
+    if (name === 'name') {
+      setUserName(value);
+      dispatch(setName(value));
+    } else {
+      setUserGit(value);
+      dispatch(setGit(value));
+    }
   };
+
   return (
     <S.BasicInfo>
       {onEdit ? (
@@ -60,22 +73,29 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
         {onEdit ? (
           <S.EditName>
             Name
-            <input onChange={nameHandler} value={userName} />
+            <input onChange={inputChangeHandler} value={userName} name='name' />
           </S.EditName>
         ) : (
           <S.UserName>{name}</S.UserName>
         )}
-        <S.GitBtn>
-          <a href={gitLink} target='_blank' rel='noreferrer'>
+        {onEdit ? (
+          <S.EditGit>
             <S.GithubIcon />
-            <span>Github</span>
-          </a>
-        </S.GitBtn>
+            <input value={userGit} onChange={inputChangeHandler} name='git' />
+          </S.EditGit>
+        ) : (
+          <S.GitBtn>
+            <a href={gitLink} target='_blank' rel='noreferrer'>
+              <S.GithubIcon />
+              <span>Github</span>
+            </a>
+          </S.GitBtn>
+        )}
         <div>
           <S.FollowrIcon />
-          {/* <span>{follower}</span> */}
-          {/* <S.ViewIcon /> */}
-          {/* <span>{view}</span> */}
+          <span>123</span>
+          <S.ViewIcon />
+          <span>321</span>
         </div>
       </div>
       <S.Buttons>{!auth && <YellowBtn>Follow</YellowBtn>}</S.Buttons>

--- a/client/src/components/User/UserDetailInfo.tsx
+++ b/client/src/components/User/UserDetailInfo.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import * as S from './UserDetailInfo.style';
-import { User } from './UserInfo';
 
 type DetailInfoProps = {
   about: string;

--- a/client/src/components/User/UserEditForm.tsx
+++ b/client/src/components/User/UserEditForm.tsx
@@ -1,18 +1,27 @@
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import * as S from './UserEditForm.style';
 import { setBlog, setAbout, setJobStatus } from '../../store/slice/editUserProfileSlice';
 import { useState } from 'react';
-// import axios from 'axios';
+import { RootState } from '../../store';
+import { useDeleteUserProfile } from '../../hooks/useDeleteUserProfile';
+import { useRouter } from '../../hooks/useRouter';
+import { logout } from '../../store/slice/loginSlice';
 
-type EditFormProps = {
-  about: string;
-  blogLink: string;
-  jobStatus: string;
+type UserEdit = {
+  userId: number;
 };
-const UserEditForm: React.FC<EditFormProps> = ({ about, blogLink, jobStatus }) => {
+const UserEditForm: React.FC<UserEdit> = ({ userId }) => {
+  const userEditInfo = useSelector((state: RootState) => {
+    return state.editUserProfile;
+  });
+  const { about, blogLink, jobStatus } = userEditInfo;
+
   const dispatch = useDispatch();
   const [userAbout, setUserAbout] = useState(about);
   const [userBlogLink, setBlogLink] = useState(blogLink);
+  const { handlerDeleteUserProfile } = useDeleteUserProfile();
+  const { routeTo } = useRouter();
+
   const aboutHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const target = e.currentTarget.value;
     setUserAbout(target);
@@ -28,8 +37,10 @@ const UserEditForm: React.FC<EditFormProps> = ({ about, blogLink, jobStatus }) =
     dispatch(setJobStatus(target));
   };
   const deleteHandler = async () => {
-    // await axios.delete(`${process.env.REACT_APP_API_URL}/user/id`);
-    // 메인 화면으로 이동 로직 필요
+    // ! : 회원 탈퇴를 하는게 확실한지 확인창 띄우기(한번에 삭제까지 실행되지 않도록 해야 할 것 같음)
+    handlerDeleteUserProfile(userId);
+    dispatch(logout(null));
+    routeTo('/');
   };
   return (
     <S.EditForm>

--- a/client/src/components/User/UserInfo.tsx
+++ b/client/src/components/User/UserInfo.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { YellowBtn } from '../common/Button.style';
-// import { user } from './mock';
 import * as S from './UserInfo.style';
 import UserEditForm from './UserEditForm';
 import UserBasicInfo from './UserBasicInfo';
@@ -9,7 +8,6 @@ import Portfolio from './Portfolio';
 import CommentContainer from './CommentContainer';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import axios from 'axios';
 import {
   setAbout,
   setBlog,
@@ -17,33 +15,20 @@ import {
   setJobStatus,
   setName,
 } from '../../store/slice/editUserProfileSlice';
-import { useMutation } from '@tanstack/react-query';
 import Loading from '../common/Loading';
 import { useGetUserProfile } from '../../hooks/useGetUserProfile';
-import { UserProfileAPI } from '../../api/client';
-
-const { patchUserProfile } = UserProfileAPI;
+import { usePatchUserProfile } from '../../hooks/usePatchUserProfile';
 
 type IdProps = {
   userId: number;
-};
-export type User = {
-  userId: number;
-  email: string;
-  name: string;
-  profileImg: string;
-  gitLink: string;
-  blogLink: string;
-  grade: string;
-  jobStatus: string;
-  about: string;
-  auth: boolean;
 };
 
 const UserInfo: React.FC<IdProps> = ({ userId }) => {
   const dispatch = useDispatch();
   const [select, setSelect] = useState<boolean>(true);
   const [onEdit, setOnEdit] = useState<boolean>(false);
+
+  const { handlerPatchProfile } = usePatchUserProfile();
 
   // * : 유저 정보를 변경할 때 사용하는 redux-toolkit 정보
   const userEditInfo = useSelector((state: RootState) => {
@@ -52,53 +37,41 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
 
   // * : 유저 정보 수정시 실행
   const submitHandler = async () => {
-    console.log(userEditInfo);
-
-    // patchUserProfile(...userEditInfo)
+    handlerPatchProfile({
+      userId,
+      name: userEditInfo.name,
+      profileImg: userEditInfo.profileImg,
+      gitLink: userEditInfo.gitLink,
+      blogLink: userEditInfo.blogLink,
+      jobStatus: userEditInfo.jobStatus,
+      about: userEditInfo.about,
+    });
     setOnEdit(false);
   };
-  // * : react-query 사용한 수정 함수(실사용에 적용되는지 확인 필요)
-  const edtiUserProfileMutation = useMutation({
-    mutationFn: (userEditInfo: any) => {
-      return axios.patch(`${process.env.REACT_APP_API_URL}/users`, {
-        // ! : 실제 사용에서는 ...user 사용 필요 없음?
-        ...userEditInfo,
-      });
-    },
-    onSuccess: () => {
-      console.log('success');
-    },
-    onError: () => {
-      console.log('Error!');
-    },
-  });
 
   // * : edit버튼이 클릭되었을 때, 현재의 유저 정보를 수정 정보에 초기화 설정(redux에서 바로 초기화할 수 있는 방법이 있는지 찾아봐야 함)
   // * : 유저가 정보를 수정할 때, 현재 기본값을 받아오기 위해 실행
   const editHandler = () => {
     setOnEdit(true);
-    dispatch(setName(UserInfo?.name));
-    dispatch(setImg(UserInfo?.profileImg));
-    dispatch(setAbout(UserInfo?.about));
-    dispatch(setJobStatus(UserInfo?.jobStatus));
-    dispatch(setBlog(UserInfo?.blogLink));
+    dispatch(setName(UserProfile?.name));
+    dispatch(setImg(UserProfile?.profileImg));
+    dispatch(setAbout(UserProfile?.about));
+    dispatch(setJobStatus(UserProfile?.jobStatus));
+    dispatch(setBlog(UserProfile?.blogLink));
   };
-
-  // ! : 실제 테스트에서는 0 대신 id값 넣을 것
-  const { UserInfo, getUserInfoError } = useGetUserProfile(userId);
-
-  // ! : 존재하지 않는 유저의 페이지인 경우 404 페이지로 이동 필요
+  
+  const { UserProfile } = useGetUserProfile(userId);
 
   return (
     <S.UserInfo>
-      {UserInfo ? (
+      {UserProfile ? (
         <>
           <UserBasicInfo
             onEdit={onEdit}
-            profileImg={UserInfo.profileImg}
-            name={UserInfo.name}
-            gitLink={UserInfo.gitLink}
-            auth={UserInfo.auth}
+            profileImg={UserProfile.profileImg}
+            name={UserProfile.name}
+            gitLink={UserProfile.gitLink}
+            auth={UserProfile.auth}
           />
           <S.SelectBtn>
             <button onClick={() => setSelect(true)} className={select ? 'select' : ''}>
@@ -110,20 +83,16 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
           </S.SelectBtn>
           {select && (
             <S.MoreInfo>
-              {UserInfo.auth && (
+              {UserProfile.auth && (
                 <>
                   {onEdit ? (
-                    <UserEditForm
-                      about={UserInfo.about}
-                      jobStatus={UserInfo.jobStatus}
-                      blogLink={UserInfo.blogLink}
-                    />
+                    <UserEditForm userId={userId} />
                   ) : (
                     <UserDetailInfo
-                      about={UserInfo.about}
-                      jobStatus={UserInfo.jobStatus}
-                      email={UserInfo.email}
-                      blogLink={UserInfo.blogLink}
+                      about={UserProfile.about}
+                      jobStatus={UserProfile.jobStatus}
+                      email={UserProfile.email}
+                      blogLink={UserProfile.blogLink}
                     />
                   )}
                   {onEdit ? (

--- a/client/src/hooks/useDeleteComment.ts
+++ b/client/src/hooks/useDeleteComment.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserCommentsAPI } from '../api/client';
+import { DeleteUserComment } from '../types';
+
+const { deleteUserComment } = UserCommentsAPI;
+
+export const useDeleteComment = (userId: number, portfolioId: number) => {
+  const queryClient = useQueryClient();
+  const { mutate: deleteUserCommentMutation } = useMutation(deleteUserComment, {
+    onMutate: () => {
+      console.log('onMutate');
+    },
+    onError: (e) => {
+      console.log(e);
+    },
+    onSuccess: (data) => {
+      console.log(data, 'success');
+      queryClient.invalidateQueries(['userComments', userId]);
+      queryClient.invalidateQueries(['commentsToUser', userId]);
+      queryClient.invalidateQueries(['commentsToPortfolio', userId]);
+      if (portfolioId) {
+        queryClient.invalidateQueries(['comment', portfolioId]);
+      }
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+  const handlerDeleteUserComment = async ({ commentId, path }: DeleteUserComment) => {
+    deleteUserCommentMutation({ commentId, path });
+  };
+  return { handlerDeleteUserComment };
+};

--- a/client/src/hooks/useDeleteUserProfile.ts
+++ b/client/src/hooks/useDeleteUserProfile.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserProfileAPI } from '../api/client';
+
+const { deleteUserProfile } = UserProfileAPI;
+
+export const useDeleteUserProfile = () => {
+  // const queryClient = useQueryClient();
+  const { mutate: deleteUserProfileMutation } = useMutation(deleteUserProfile, {
+    onMutate: () => {
+      console.log('onMutate');
+    },
+    onError: (e) => {
+      console.log(e);
+    },
+    onSuccess: (data) => {
+      console.log(data, 'success');
+      // queryClient.invalidateQueries(['userProfile', userId]);
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+  const handlerDeleteUserProfile = async (userId: number) => {
+    deleteUserProfileMutation(userId);
+  };
+  return { handlerDeleteUserProfile };
+};

--- a/client/src/hooks/useGetCommentsToPortfolio.ts
+++ b/client/src/hooks/useGetCommentsToPortfolio.ts
@@ -10,7 +10,7 @@ export const useGetCommentsToPortfolio = (userId: number) => {
     isError: getCommentsToPortfolioError,
     data: CommentsToPortfolio,
   } = useQuery<GetUserComment[], Error>({
-    queryKey: ['commentsToPortfolio'],
+    queryKey: ['commentsToPortfolio', userId],
     queryFn: () => getCommentsToPortfolio(userId),
   });
   return { getCommentsToPortfolioLoading, getCommentsToPortfolioError, CommentsToPortfolio };

--- a/client/src/hooks/useGetCommentsToUser.ts
+++ b/client/src/hooks/useGetCommentsToUser.ts
@@ -10,7 +10,7 @@ export const useGetCommentsToUser = (userId: number) => {
     isError: getCommentsToUserError,
     data: CommentsToUser,
   } = useQuery<GetUserComment[], Error>({
-    queryKey: ['commentsToUser'],
+    queryKey: ['commentsToUser', userId],
     queryFn: () => getCommentsToUser(userId),
   });
   return { getCommentsToUserLoading, getCommentsToUserError, CommentsToUser };

--- a/client/src/hooks/useGetUserComment.ts
+++ b/client/src/hooks/useGetUserComment.ts
@@ -10,7 +10,7 @@ export const useGetUserComments = (userId: number) => {
     isError: getUserCommentError,
     data: UserComments,
   } = useQuery<GetUserComment[], Error>({
-    queryKey: ['userComments'],
+    queryKey: ['userComments', userId],
     queryFn: () => getUserComments(userId),
   });
   return { getUserCommentLoading, getUserCommentError, UserComments };

--- a/client/src/hooks/useGetUserPortfolios.ts
+++ b/client/src/hooks/useGetUserPortfolios.ts
@@ -10,7 +10,7 @@ export const useGetUserPortfolios = (userId: number) => {
     isError: getUserPortfoliosError,
     data: UserPortfolios,
   } = useQuery<GetUserPortfolio[], Error>({
-    queryKey: ['userPortfolios'],
+    queryKey: ['userPortfolios', userId],
     queryFn: () => getUserPortfolio(userId),
   });
   return { getUserPortfoliosLoading, getUserPortfoliosError, UserPortfolios };

--- a/client/src/hooks/useGetUserProfile.ts
+++ b/client/src/hooks/useGetUserProfile.ts
@@ -8,16 +8,22 @@ const { getUserProfile } = UserProfileAPI;
 export const useGetUserProfile = (userId: number) => {
   const navigate = useNavigate();
   const {
-    isLoading: getUserInfoLoading,
-    isError: getUserInfoError,
-    data: UserInfo,
+    isLoading: getUserProfileLoading,
+    isError: getUserProfileError,
+    data: UserProfile,
   } = useQuery<GetUserProfile, Error>({
-    queryKey: ['userInfo'],
+    queryKey: ['UserProfile', userId],
     queryFn: () => getUserProfile(userId),
     onError: () => {
       console.error('해당하는 유저를 찾을 수 없습니다.');
       navigate('/*');
     },
+    retry: (failureCount, error) => {
+      if (error.message === 'Request failed with status code 404') {
+        return false;
+      }
+      return failureCount < 5;
+    },
   });
-  return { getUserInfoLoading, getUserInfoError, UserInfo };
+  return { getUserProfileLoading, getUserProfileError, UserProfile };
 };

--- a/client/src/hooks/usePatchUserComment.ts
+++ b/client/src/hooks/usePatchUserComment.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PatchUserComment } from '../types';
+import { UserCommentsAPI } from '../api/client';
+
+const { patchUserComment } = UserCommentsAPI;
+
+export const usePatchUserComment = (userId: number, portfolioId: number) => {
+  const queryClient = useQueryClient();
+  const { mutate: patchUserCommentMutation } = useMutation(patchUserComment, {
+    onMutate: () => {
+      console.log('onMutate');
+    },
+    onError: (e) => {
+      console.log(e);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['userComments', userId]);
+      queryClient.invalidateQueries(['commentsToUser', userId]);
+      queryClient.invalidateQueries(['commentsToPortfolio', userId]);
+      if (portfolioId) {
+        queryClient.invalidateQueries(['comment', portfolioId]);
+      }
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+  const handlePatchUserComment = async ({
+    userId,
+    content,
+    path,
+    pathId,
+    commentId,
+  }: PatchUserComment) => {
+    patchUserCommentMutation({
+      userId,
+      content,
+      path,
+      pathId,
+      commentId,
+    });
+  };
+  return { patchUserCommentMutation, handlePatchUserComment };
+};

--- a/client/src/hooks/usePatchUserProfile.ts
+++ b/client/src/hooks/usePatchUserProfile.ts
@@ -1,38 +1,42 @@
-// ! : 유저 정보를 patch하기 위해선 react-toolkit의 정보가 필요(훅 사용 해야 함)
-
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { getUserIdFromAccessToken } from '../utils/getUserIdFromAccessToken';
-import { useAppSelector } from './reduxHook';
+import { useMutation } from '@tanstack/react-query';
 import { PatchUserProfile } from '../types';
 import { UserProfileAPI } from '../api/client';
 
 const { patchUserProfile } = UserProfileAPI;
 
 export const usePatchUserProfile = () => {
-  const token = useAppSelector((state) => state.login.accessToken);
-  const isLogin = useAppSelector((state) => state.login.isLogin);
-
-  const userId = getUserIdFromAccessToken(isLogin, token);
-
-  const queryClient = useQueryClient();
-  const { mutate: patchProfile } = useMutation({
-    mutationFn: patchUserProfile,
-    onSuccess: () => {
-      queryClient.invalidateQueries(['profile']);
+  const { mutate: patchUserProfileMutation } = useMutation(patchUserProfile, {
+    onMutate: () => {
+      console.log('onMutate');
     },
     onError: (e) => {
       console.log(e);
     },
+    onSuccess: (data) => {
+      console.log(data, 'success');
+    },
+    onSettled: () => {
+      console.log('end');
+    },
   });
-  const patchProfileAction = (
-    userId: number,
-    name: string,
-    profileImg: string,
-    gitLink: string,
-    blogLink: string,
-    jobStatus: string,
-    about: string,
-  ) => {
-    patchProfile;
+  const handlerPatchProfile = async ({
+    userId,
+    name,
+    profileImg,
+    gitLink,
+    blogLink,
+    jobStatus,
+    about,
+  }: PatchUserProfile) => {
+    patchUserProfileMutation({
+      userId,
+      name,
+      profileImg,
+      gitLink,
+      blogLink,
+      jobStatus,
+      about,
+    });
   };
+  return { patchUserProfileMutation, handlerPatchProfile };
 };

--- a/client/src/hooks/usePostUserComment.ts
+++ b/client/src/hooks/usePostUserComment.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserCommentsAPI } from '../api/client';
+import { useAppSelector } from './reduxHook';
+import { getUserIdFromAccessToken } from '../utils/getUserIdFromAccessToken';
+
+const { postUserComment } = UserCommentsAPI;
+
+export const usePostUserComment = (userId: number) => {
+  const token = useAppSelector((state) => state.login.accessToken);
+  const isLogin = useAppSelector((state) => state.login.isLogin);
+  const writerId = getUserIdFromAccessToken(isLogin, token);
+
+  const queryClient = useQueryClient();
+  const { mutate: postUserCommentMutation } = useMutation(postUserComment, {
+    onMutate: () => {
+      console.log('onMutate');
+    },
+    onError: (e) => {
+      console.log(e);
+    },
+    onSuccess: (data) => {
+      console.log(data, 'success');
+      queryClient.invalidateQueries(['userComments', userId]);
+    },
+    onSettled: () => {
+      console.log('end');
+    },
+  });
+  const handlerPostUserComment = async (userId: number, content: string) => {
+    if (writerId) {
+      postUserCommentMutation({ userId, writerId, content });
+    }
+  };
+  return { handlerPostUserComment };
+};

--- a/client/src/pages/User.tsx
+++ b/client/src/pages/User.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 
 function User() {
   // TODO : 해당 유저 데이터의 id값으로 정보, 포트폴리오, 코멘트 모두 가져오기
-  const { id:userId } = useParams() as { id: string };
+  const { userId } = useParams() as { userId: string };
 
   return (
     <S.User>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -48,7 +48,7 @@ const routerData: RouterElement[] = [
   },
   {
     id: 3,
-    path: '/User/:id',
+    path: '/User/:userId',
     label: 'User',
     element: <User />,
     withAuth: false,

--- a/client/src/store/slice/editUserProfileSlice.ts
+++ b/client/src/store/slice/editUserProfileSlice.ts
@@ -7,6 +7,7 @@ type UserInfo = {
   profileImg: File | null;
   about: string;
   jobStatus: string;
+  gitLink: string;
   blogLink: string;
 };
 
@@ -15,6 +16,7 @@ const initialState: UserInfo = {
   profileImg: null,
   about: '',
   jobStatus: '',
+  gitLink: '',
   blogLink: '',
 };
 
@@ -29,17 +31,29 @@ const EditUserProfileSlice = createSlice({
       state.profileImg = action.payload;
     },
     setAbout: (state, action) => {
-      state.about = action.payload;
+      if (action.payload) {
+        state.about = action.payload;
+      } else {
+        state.about = '';
+      }
     },
     setJobStatus: (state, action) => {
-      state.jobStatus = action.payload;
+      if (action.payload) {
+        state.jobStatus = action.payload;
+      } else {
+        state.jobStatus = 'JOB_SEEKING';
+      }
+    },
+    setGit: (state, action) => {
+      action.payload ? (state.gitLink = action.payload) : (state.gitLink = '');
     },
     setBlog: (state, action) => {
-      state.blogLink = action.payload;
+      action.payload ? (state.blogLink = action.payload) : (state.blogLink = '');
     },
   },
 });
 
-export const { setName, setImg, setAbout, setJobStatus, setBlog } = EditUserProfileSlice.actions;
+export const { setName, setImg, setAbout, setJobStatus, setGit, setBlog } =
+  EditUserProfileSlice.actions;
 
 export default EditUserProfileSlice.reducer;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -27,26 +27,54 @@ export type GetUserPortfolio = {
 };
 
 export type GetUserComment = {
+  // 댓글 공통
   userId: number;
-  writerId: number;
-  writerName: string;
   content: string;
   createdAt: string;
   updatedAt: string;
+  auth: boolean;
+
+  // 유저 댓글
+  writerProfileImg?: string;
+  writerId?: number;
+  writerName?: string;
   userCommentId?: number;
+
+  // 포트폴리오 댓글
+  userName?: string;
+  userProfileImg?: string;
   portfolioCommentId?: number;
   portfolioId?: number;
+};
+
+export type PostUserComment = {
+  userId: number;
+  writerId: number;
+  content: string;
 };
 
 export type PatchUserProfile = {
   userId: number;
   name: string;
-  // 타입이 File이어야하는거 아닌지 문의하기
-  profileImg: string;
+  profileImg: File | null;
   gitLink: string;
   blogLink: string;
   jobStatus: string;
   about: string;
+};
+
+export type PatchUserComment = {
+  userId: number;
+  content: string;
+  path: string;
+
+  pathId:number;
+  commentId:number;
+};
+
+export type DeleteUserComment = {
+  commentId: number;
+  path: string;
 };
 
 // Portfolio


### PR DESCRIPTION
### Branch
fe-feat/유저페이지/#70 => fe

### 참고 사항
- 유저 정보 조회 및 수정, 탈퇴 기능 구현(Auth 적용은 아직 진행 중)
- 유저 관련 댓글 조회 및 추가, 수정, 삭제 기능 구현
- router의 유저 페이지 :id 를 :userId 로 수정
- useGetUserInfo의 UserInfo 변수 이름을 UserProfile로 변경
- Portfolio의 정렬은 아직 미구현(서버측에서 수정 후 알려주신다 하셨음)