### PR TITLE
feat: UserPortfolios 무한스크롤 구현

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -198,11 +198,19 @@ export const PortfolioCommentAPI = {
 // * : UserComponent
 export const UserProfileAPI = {
   getUserProfile: async (userId: number): Promise<GetUserProfile> => {
-    // ! : 실제 사용을 할 때는 /users/1/profile
-    const userProfileData = await tokenClient.get(
-      `${process.env.REACT_APP_API_URL}/users/${userId}/profile`,
-    );
+    const userProfileData = await tokenClient.get(`/users/${userId}/profile`);
     return userProfileData.data.data;
+  },
+  postUserImg: async (userId: number, userImg: File) => {
+    // ! : 파일은 form 데이터로 전송
+    const profileImg = new FormData();
+    profileImg.append('profileImg', userImg);
+    const axiosConfig = {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    };
+    return await tokenClient.post(`/users/${userId}/profile-img-upload`, profileImg, axiosConfig);
   },
   patchUserProfile: async ({
     userId,
@@ -213,7 +221,7 @@ export const UserProfileAPI = {
     jobStatus,
     about,
   }: PatchUserProfile) => {
-    await tokenClient.patch(`${process.env.REACT_APP_API_URL}/users/${userId}`, {
+    await tokenClient.patch(`/users/${userId}`, {
       name,
       profileImg,
       gitLink,
@@ -223,7 +231,7 @@ export const UserProfileAPI = {
     });
   },
   deleteUserProfile: async (userId: number) => {
-    await tokenClient.delete(`${process.env.REACT_APP_API_URL}/users/${userId}`);
+    await tokenClient.delete(`/users/${userId}`);
   },
 };
 
@@ -236,30 +244,27 @@ export const UserPortfolioAPI = {
     return userPortfoliosData.data.data;
   },
 };
-
 export const UserCommentsAPI = {
   getUserComments: async (userId: number): Promise<GetUserComment[]> => {
     const userCommentsData = await tokenClient.get(
-      `${process.env.REACT_APP_API_URL}/api/usercomments/users/${userId}?page=1&size=10`,
+      `/api/usercomments/users/${userId}?page=1&size=10`,
     );
     return userCommentsData.data.data;
   },
   // * : 한 유저가 다른 사람의 포트폴리에 작성한 댓글
   getCommentsToPortfolio: async (userId: number): Promise<GetUserComment[]> => {
-    const commentsToPortfolioData = await tokenClient.get(
-      `${process.env.REACT_APP_API_URL}/api/portfoliocomments/users/${userId}`,
-    );
+    const commentsToPortfolioData = await tokenClient.get(`/api/portfoliocomments/users/${userId}`);
     return commentsToPortfolioData.data.data;
   },
   // * : 한 유저가 다른 사람에게 작성한 댓글
   getCommentsToUser: async (userId: number): Promise<GetUserComment[]> => {
     const commentsToUserData = await tokenClient.get(
-      `${process.env.REACT_APP_API_URL}/api/usercomments/writers/${userId}?page=1&size=10`,
+      `/api/usercomments/writers/${userId}?page=1&size=10`,
     );
     return commentsToUserData.data.data;
   },
   postUserComment: async ({ userId, writerId, content }: PostUserComment) => {
-    return await tokenClient.post(`${process.env.REACT_APP_API_URL}/api/usercomments`, {
+    return await tokenClient.post('/api/usercomments', {
       userId,
       writerId,
       content,
@@ -267,7 +272,7 @@ export const UserCommentsAPI = {
   },
   patchUserComment: async ({ userId, content, path, pathId, commentId }: PatchUserComment) => {
     await tokenClient.patch(
-      `${process.env.REACT_APP_API_URL}/api/${path}/${commentId}`,
+      `/api/${path}/${commentId}`,
       path === 'usercomments'
         ? {
             userCommentId: commentId,
@@ -280,7 +285,7 @@ export const UserCommentsAPI = {
   },
   // ! : 전달되는게 어떤 id값인지 확인 필요
   deleteUserComment: async ({ commentId, path }: DeleteUserComment) => {
-    await tokenClient.delete(`${process.env.REACT_APP_API_URL}/api/${path}/${commentId}`);
+    await tokenClient.delete(`/api/${path}/${commentId}`);
   },
 };
 

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -11,7 +11,6 @@ import {
   GetPortfolioPage,
   PostPortfolioComment,
   PatchPortfolioComment,
-  GetUserPortfolio,
   GetUserProfile,
   GetUserComment,
   PatchUserProfile,
@@ -22,6 +21,7 @@ import {
   PatchUserComment,
   DeleteUserComment,
   LikeBtn,
+  GetUserPortfolioPage,
 } from '../types/index';
 
 const REFRESH_URL = ''; // refresh URL을 새롭게 추가를 해야 한다.
@@ -236,14 +236,19 @@ export const UserProfileAPI = {
 };
 
 export const UserPortfolioAPI = {
-  getUserPortfolio: async (userId: number): Promise<GetUserPortfolio[]> => {
-    // ! : sort 기능 추가 필요(아직 테스트하지 못함)
+  getUserPortfolio: async (
+    userId: number,
+    sort: string,
+    page: number,
+    size: string,
+  ): Promise<GetUserPortfolioPage> => {
     const userPortfoliosData = await tokenClient.get(
-      `${process.env.REACT_APP_API_URL}/portfolios/${userId}/portfolios?sortBy=createdAt&page=1&size=15`,
+      `/portfolios/users/${userId}?page=${page}&size=${size}&sortBy=${sort}`,
     );
-    return userPortfoliosData.data.data;
+    return { ...userPortfoliosData.data, currentPage: page };
   },
 };
+
 export const UserCommentsAPI = {
   getUserComments: async (userId: number): Promise<GetUserComment[]> => {
     const userCommentsData = await tokenClient.get(

--- a/client/src/components/User/CommentContainer.style.ts
+++ b/client/src/components/User/CommentContainer.style.ts
@@ -6,8 +6,8 @@ export const CommentContainer = styled.div`
   padding: 10px;
   border-top: 1px double black;
 `;
-export const Comments = styled.ul`
-  height: 300px;
+export const Comments = styled.ul<{ CommentLen: number }>`
+  height: ${(props) => (props.CommentLen <= 3 ? `${props.CommentLen * 125}px` : '390px')};
   overflow: scroll;
   -ms-overflow-style: none;
   ::-webkit-scrollbar {

--- a/client/src/components/User/CommentContainer.tsx
+++ b/client/src/components/User/CommentContainer.tsx
@@ -19,7 +19,7 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
 
   const addHandler = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO : 데이터 전송
+    // TODO : 데이터 전
     handlerPostUserComment(userId, content);
     setContent('');
   };
@@ -46,23 +46,21 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
       </S.SelectBtn>
       {selectComment ? (
         <>
-          <S.Comments>
-            {UserComments && (
-              <>
-                {UserComments.length > 0 ? (
-                  <>
-                    {UserComments.map((ele) => (
-                      <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
-                    ))}
-                  </>
-                ) : (
-                  <>
-                    <p></p>
-                  </>
-                )}
-              </>
-            )}
-          </S.Comments>
+          {UserComments && (
+            <>
+              {UserComments.length > 0 ? (
+                <S.Comments CommentLen={UserComments.length}>
+                  {UserComments.map((ele) => (
+                    <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
+                  ))}
+                </S.Comments>
+              ) : (
+                <>
+                  <p>작성된 댓글이 없습니다.</p>
+                </>
+              )}
+            </>
+          )}
           <S.CommentAdd onSubmit={addHandler}>
             <label htmlFor='Comment'></label>
             <textarea id='Comment' value={content} onChange={contentChangeHandler} />
@@ -84,19 +82,45 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
             </button>
           </S.CategoryBtns>
           {category ? (
-            <S.Comments>
-              {CommentsToUser &&
-                CommentsToUser?.map((ele) => (
-                  <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
-                ))}
-            </S.Comments>
+            <>
+              {CommentsToUser && (
+                <>
+                  {CommentsToUser.length > 0 ? (
+                    <S.Comments CommentLen={CommentsToUser.length}>
+                      {CommentsToUser.map((ele) => (
+                        <CommentItem key={ele.userCommentId} data={ele} path='usercomments' />
+                      ))}
+                    </S.Comments>
+                  ) : (
+                    <>
+                      <p>작성한 댓글이 없습니다.</p>
+                    </>
+                  )}
+                </>
+              )}
+            </>
           ) : (
-            <S.Comments>
-              {CommentsToPortfolio &&
-                CommentsToPortfolio?.map((ele) => (
-                  <CommentItem key={ele.portfolioCommentId} data={ele} path='portfoliocomments' />
-                ))}
-            </S.Comments>
+            <>
+              {CommentsToPortfolio && (
+                <>
+                  {CommentsToPortfolio.length > 0 ? (
+                    <S.Comments CommentLen={CommentsToPortfolio.length}>
+                      {CommentsToPortfolio.map((ele) => (
+                        <CommentItem
+                          key={ele.userCommentId}
+                          data={ele}
+                          path='portfoliocomments'
+                        />
+                      ))}
+                    </S.Comments>
+                  ) : (
+                    <>
+                      <p>작성한 댓글이 없습니다.</p>
+                    </>
+                  )}
+                </>
+              )}
+            </>
           )}
         </>
       )}

--- a/client/src/components/User/CommentItem.style.ts
+++ b/client/src/components/User/CommentItem.style.ts
@@ -26,6 +26,11 @@ export const CommentItem = styled.li`
     resize: none;
   }
 `;
+export const TextBox = styled.p`
+  width: 100%;
+  margin: 8px 0;
+  overflow-wrap: break-word;
+`;
 export const ImgBox = styled.div`
   width: 20px;
   height: 20px;

--- a/client/src/components/User/CommentItem.tsx
+++ b/client/src/components/User/CommentItem.tsx
@@ -1,9 +1,11 @@
-import React, { FormEvent, useRef, useState } from 'react';
+import React, { FormEvent, useEffect, useRef, useState } from 'react';
 import * as S from './CommentItem.style';
 import { usePatchUserComment } from '../../hooks/usePatchUserComment';
 import { useDeleteComment } from '../../hooks/useDeleteComment';
 import { GetUserComment } from '../../types';
 import { useRouter } from '../../hooks/useRouter';
+import { useAppSelector } from '../../hooks/reduxHook';
+import { getUserIdFromAccessToken } from '../../utils/getUserIdFromAccessToken';
 
 type CommentItemProps = {
   data: GetUserComment;
@@ -41,15 +43,36 @@ const CommentItem: React.FC<CommentItemProps> = ({ data, path }) => {
   };
   const onClickHandler = () => {
     if (path === 'usercomments') {
-      console.log('?');
       routeTo(`/User/${data.userId}`);
     } else {
       routeTo(`/Detail/${data.portfolioId}`);
     }
   };
-  // ! : 로그인한 유저 === 페이지 유저 : 삭제 버튼 보여야 함
-  // ! : 로그인한 유저 === 작성자 : 삭제 & 수정 버튼 보여야 함
+  // ! : 로그인한 유저 === 페이지 유저 : 삭제 버튼 보여야 함 (isAuth ? 삭제 버튼 표시)
+  // ! : 로그인한 유저 === 작성자 : 삭제 & 수정 버튼 보여야 함 (isWriter ? 삭제 & 수정 버튼 표시)
+  // ? : 로그인한 유저 === 페이지 유저 === 작성자 일때도 삭제 & 수정버튼 보여야 함. 어떻게 처리할 것인지.
+  // ? : isAuth 가 true이고 isWriter가 false이면 삭제 버튼만
+  // ? : isAuth 가 true이고 isWriter가 true 이면 삭제&수정
   // ! : Auth 데이터가 어떻게 도착하는지 보고 반영하기
+
+  // ! : 임시 코드. 서버에서 auth 받아오면 지울 것.
+
+  const token = localStorage.getItem('accessToken');
+  const isLogin = useAppSelector((state) => state.login.isLogin);
+  const loginUser = getUserIdFromAccessToken(isLogin, token);
+
+  const [isAuth, setIsAuth] = useState(false);
+  const [isWriter, setIsWriter] = useState(false);
+
+  useEffect(() => {
+    if (loginUser === data.writerId) {
+      setIsWriter(true);
+    }
+    if (loginUser === data.userId) {
+      setIsAuth(true);
+    }
+  }, [data]);
+
   return (
     <S.CommentItem>
       <S.DelBtn onClick={deleteHandler} />
@@ -60,7 +83,7 @@ const CommentItem: React.FC<CommentItemProps> = ({ data, path }) => {
           <textarea ref={CommentRef} value={editText} onChange={onChangeHandler} />
         </form>
       ) : (
-        <p>{editText}</p>
+        <S.TextBox>{editText}</S.TextBox>
       )}
       {/* 본인의 페이지 일 때는 표시하지 않기 */}
       <S.LinkIcon onClick={onClickHandler} />

--- a/client/src/components/User/Portfolio.style.ts
+++ b/client/src/components/User/Portfolio.style.ts
@@ -26,3 +26,11 @@ export const PortfolioBtns = styled.div`
     border: 0;
   }
 `;
+export const ErrorContainer = styled.p`
+  margin-top: 50px;
+  text-align: center;
+`;
+
+export const Target = styled.div`
+  height: 1px;
+`;

--- a/client/src/components/User/UserBasicInfo.style.ts
+++ b/client/src/components/User/UserBasicInfo.style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { RxGithubLogo, RxPerson } from 'react-icons/rx';
+import { RxGithubLogo, RxPerson, RxSketchLogo } from 'react-icons/rx';
 import { IoMdEye } from 'react-icons/io';
 
 import { COLOR } from '../../constants/index';
@@ -67,6 +67,7 @@ export const UserImg = styled.div`
   }
   margin-right: 15px;
 `;
+export const UserNameBox = styled.div``;
 export const UserName = styled.p`
   font-weight: bold;
   font-size: 1.5rem;
@@ -92,7 +93,11 @@ export const Buttons = styled.div`
 `;
 export const GithubIcon = styled(RxGithubLogo)``;
 export const ViewIcon = styled(IoMdEye)`
-  /* margin: 0 10px; */
   margin-left: 8px;
 `;
 export const FollowrIcon = styled(RxPerson)``;
+export const GradeIcon = styled(RxSketchLogo)<{ gradecolor: string }>`
+  color: ${(props) => props.gradecolor};
+  font-size: 1rem;
+  margin: 0;
+`;

--- a/client/src/components/User/UserBasicInfo.tsx
+++ b/client/src/components/User/UserBasicInfo.tsx
@@ -5,22 +5,28 @@ import * as S from './UserBasicInfo.style';
 import { setGit, setImg, setName } from '../../store/slice/editUserProfileSlice';
 import { useState } from 'react';
 import { RootState } from '../../store';
+import { UserProfileAPI } from '../../api/client';
 
 type UserBasicInfoProps = {
+  userId: number;
   onEdit: boolean;
   name: string;
   profileImg: string;
   gitLink: string;
   auth: boolean;
+  grade: string;
 };
 const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
+  userId,
   onEdit,
   name,
   profileImg,
   gitLink,
   auth,
+  grade,
 }) => {
   const dispatch = useDispatch();
+  const { postUserImg } = UserProfileAPI;
   const userEditInfo = useSelector((state: RootState) => {
     return state.editUserProfile;
   });
@@ -29,8 +35,9 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
   const [userName, setUserName] = useState<string>(name);
   // ! : input에 null값을 넣지 않기 위해 editSlice의 정보 사용,(서버에서 처리해주면 기존값 사용해도 괜찮음)
   const [userGit, setUserGit] = useState<string>(editGitLink);
+  const [gradecolor, setGradecolor] = useState<string>('brown');
 
-  const fileUploadHanlder = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const fileUploadHanlder = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.currentTarget;
     const files = (target.files as FileList)[0];
     if (!files) return;
@@ -39,7 +46,12 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
       setPhoto(reader.result as string);
     };
     reader.readAsDataURL(files);
-    dispatch(setImg({ ...files }));
+    postUserImg(userId, files)
+      .then((res) => {
+        console.log(res.data);
+        dispatch(setImg(res.data));
+      })
+      .catch((e) => console.log(e));
   };
 
   const inputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -52,6 +64,23 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
       dispatch(setGit(value));
     }
   };
+
+  // const changeGradeColor = () => {
+  //   switch (grade) {
+  //     case 'NOVICE':
+  //       return setGradeColor('brown');
+  //     case 'INTERMEDIATE':
+  //       return setGradeColor('silver');
+  //     case 'ADVANCED':
+  //       return setGradeColor('gold');
+  //     case 'EXPERT':
+  //       return setGradeColor('red');
+  //     case 'MASTER':
+  //       return setGradeColor('');
+  //     default:
+  //       return setGradeColor('brown');
+  //   }
+  // };
 
   return (
     <S.BasicInfo>
@@ -70,14 +99,19 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
         </S.UserImg>
       )}
       <div>
-        {onEdit ? (
-          <S.EditName>
-            Name
-            <input onChange={inputChangeHandler} value={userName} name='name' />
-          </S.EditName>
-        ) : (
-          <S.UserName>{name}</S.UserName>
-        )}
+        <S.UserNameBox>
+          {onEdit ? (
+            <S.EditName>
+              Name
+              <input onChange={inputChangeHandler} value={userName} name='name' />
+            </S.EditName>
+          ) : (
+            <S.UserName>
+              <S.GradeIcon gradecolor={gradecolor} />
+              <span>{name}</span>
+            </S.UserName>
+          )}
+        </S.UserNameBox>
         {onEdit ? (
           <S.EditGit>
             <S.GithubIcon />
@@ -85,10 +119,16 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({
           </S.EditGit>
         ) : (
           <S.GitBtn>
-            <a href={gitLink} target='_blank' rel='noreferrer'>
-              <S.GithubIcon />
-              <span>Github</span>
-            </a>
+            {gitLink ? (
+              <a href={gitLink} target='_blank' rel='noreferrer'>
+                <S.GithubIcon />
+                <span>Github</span>
+              </a>
+            ) : (
+              <>
+                <S.GithubIcon />
+              </>
+            )}
           </S.GitBtn>
         )}
         <div>

--- a/client/src/components/User/UserEditForm.style.ts
+++ b/client/src/components/User/UserEditForm.style.ts
@@ -33,15 +33,15 @@ export const EditForm = styled.form`
     border: 1px solid;
     border-radius: 5px;
   }
-  button {
-    position: relative;
-    left: 85%;
-    font-size: 0.8rem;
-    color: ${subFontColor};
-  }
   svg {
     font-size: 1.3rem;
   }
+`;
+export const DeleteBtn = styled.button`
+  position: relative;
+  left: 85%;
+  font-size: 0.8rem;
+  color: ${subFontColor};
 `;
 export const EditSelect = styled.select`
   width: 100%;

--- a/client/src/components/User/UserEditForm.tsx
+++ b/client/src/components/User/UserEditForm.tsx
@@ -6,6 +6,8 @@ import { RootState } from '../../store';
 import { useDeleteUserProfile } from '../../hooks/useDeleteUserProfile';
 import { useRouter } from '../../hooks/useRouter';
 import { logout } from '../../store/slice/loginSlice';
+import ConfirmationModal from '../common/ConfirmationModal';
+import { setOpen } from '../../store/slice/modalSlice';
 
 type UserEdit = {
   userId: number;
@@ -14,13 +16,13 @@ const UserEditForm: React.FC<UserEdit> = ({ userId }) => {
   const userEditInfo = useSelector((state: RootState) => {
     return state.editUserProfile;
   });
+  const { routeTo } = useRouter();
   const { about, blogLink, jobStatus } = userEditInfo;
 
   const dispatch = useDispatch();
   const [userAbout, setUserAbout] = useState(about);
   const [userBlogLink, setBlogLink] = useState(blogLink);
-  const { handlerDeleteUserProfile } = useDeleteUserProfile();
-  const { routeTo } = useRouter();
+  const { handlerDeleteUserProfile } = useDeleteUserProfile(userId);
 
   const aboutHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const target = e.currentTarget.value;
@@ -36,10 +38,14 @@ const UserEditForm: React.FC<UserEdit> = ({ userId }) => {
     const target = e.currentTarget.value;
     dispatch(setJobStatus(target));
   };
+  const onModalHandler = () => {
+    dispatch(setOpen(null));
+  };
   const deleteHandler = async () => {
-    // ! : 회원 탈퇴를 하는게 확실한지 확인창 띄우기(한번에 삭제까지 실행되지 않도록 해야 할 것 같음)
     handlerDeleteUserProfile(userId);
     dispatch(logout(null));
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
     routeTo('/');
   };
   return (
@@ -72,9 +78,17 @@ const UserEditForm: React.FC<UserEdit> = ({ userId }) => {
           value={userBlogLink}
         />
       </label>
-      <button type='button' onClick={deleteHandler}>
+      <S.DeleteBtn type='button' onClick={onModalHandler}>
         회원 탈퇴
-      </button>
+      </S.DeleteBtn>
+      <ConfirmationModal
+        title='회원을 탈퇴하시겠습니까?'
+        text1='회원을 탈퇴하시면 입력한 모든 정보가 삭제되며,'
+        text2='복구할 수 없게 됩니다.'
+        text3='정말로 탈퇴하시겠습니까?'
+        onClickHandler={deleteHandler}
+        type='warning'
+      />
     </S.EditForm>
   );
 };

--- a/client/src/components/User/UserInfo.tsx
+++ b/client/src/components/User/UserInfo.tsx
@@ -28,7 +28,7 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
   const [select, setSelect] = useState<boolean>(true);
   const [onEdit, setOnEdit] = useState<boolean>(false);
 
-  const { handlerPatchProfile } = usePatchUserProfile();
+  const { handlerPatchProfile } = usePatchUserProfile(userId);
 
   // * : 유저 정보를 변경할 때 사용하는 redux-toolkit 정보
   const userEditInfo = useSelector((state: RootState) => {
@@ -59,7 +59,7 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
     dispatch(setJobStatus(UserProfile?.jobStatus));
     dispatch(setBlog(UserProfile?.blogLink));
   };
-  
+
   const { UserProfile } = useGetUserProfile(userId);
 
   return (
@@ -67,11 +67,13 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
       {UserProfile ? (
         <>
           <UserBasicInfo
+            userId={userId}
             onEdit={onEdit}
             profileImg={UserProfile.profileImg}
             name={UserProfile.name}
             gitLink={UserProfile.gitLink}
             auth={UserProfile.auth}
+            grade={UserProfile.grade}
           />
           <S.SelectBtn>
             <button onClick={() => setSelect(true)} className={select ? 'select' : ''}>
@@ -83,28 +85,30 @@ const UserInfo: React.FC<IdProps> = ({ userId }) => {
           </S.SelectBtn>
           {select && (
             <S.MoreInfo>
-              {UserProfile.auth && (
-                <>
-                  {onEdit ? (
-                    <UserEditForm userId={userId} />
-                  ) : (
-                    <UserDetailInfo
-                      about={UserProfile.about}
-                      jobStatus={UserProfile.jobStatus}
-                      email={UserProfile.email}
-                      blogLink={UserProfile.blogLink}
-                    />
-                  )}
-                  {onEdit ? (
-                    <S.DetailBtns>
-                      <YellowBtn onClick={submitHandler}>수정 완료</YellowBtn>
-                      <button onClick={() => setOnEdit(false)}>수정 취소</button>
-                    </S.DetailBtns>
-                  ) : (
-                    <YellowBtn onClick={editHandler}>정보 수정</YellowBtn>
-                  )}
-                </>
-              )}
+              <>
+                {onEdit ? (
+                  <UserEditForm userId={userId} />
+                ) : (
+                  <UserDetailInfo
+                    about={UserProfile.about}
+                    jobStatus={UserProfile.jobStatus}
+                    email={UserProfile.email}
+                    blogLink={UserProfile.blogLink}
+                  />
+                )}
+                {UserProfile.auth && (
+                  <>
+                    {onEdit ? (
+                      <S.DetailBtns>
+                        <YellowBtn onClick={submitHandler}>수정 완료</YellowBtn>
+                        <button onClick={() => setOnEdit(false)}>수정 취소</button>
+                      </S.DetailBtns>
+                    ) : (
+                      <YellowBtn onClick={editHandler}>정보 수정</YellowBtn>
+                    )}
+                  </>
+                )}
+              </>
               <CommentContainer userId={userId} />
             </S.MoreInfo>
           )}

--- a/client/src/components/common/ConfirmationModal.style.ts
+++ b/client/src/components/common/ConfirmationModal.style.ts
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+export const ModalBackground = styled.div<{ OnOff: boolean }>`
+  display: ${(props) => (props.OnOff ? 'block' : 'none')};
+  width: 100vw;
+  height: 100vh;
+  background-color: #000000cd;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 500;
+`;
+export const ModalContainer = styled.div`
+  width: 500px;
+  height: 280px;
+  background-color: white;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translateY(-50%) translateX(-50%);
+  border-radius: 20px;
+  overflow: hidden;
+`;
+
+export const Title = styled.div`
+  height: 80px;
+  background-color: black;
+  color: white;
+  font-size: 1.5rem;
+  text-align: center;
+  line-height: 80px;
+`;
+export const TextBox = styled.div`
+  padding: 20px;
+  text-align: center;
+`;
+export const BtnBox = styled.div`
+  position: absolute;
+  width: 100%;
+  left: 0;
+  bottom: 30px;
+  display: flex;
+  justify-content: center;
+  button {
+    width: 150px;
+    margin: 0 20px;
+    &:hover {
+      color: gray;
+    }
+  }
+`;

--- a/client/src/components/common/ConfirmationModal.tsx
+++ b/client/src/components/common/ConfirmationModal.tsx
@@ -1,0 +1,76 @@
+import * as S from './ConfirmationModal.style';
+import { YellowBtn } from '../common/Button.style';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import { setClose } from '../../store/slice/modalSlice';
+
+// * : 실행 확인용 모달
+// 모달을 사용하는 컴포넌트에서 => 'dispatch(setOpen(null));'로 모달창 오픈
+// 줄바꿈을 위해 text1,2,3으로 구분(좋은 방법 생각나면 수정)
+// onClickHandler : 확인 버튼을 눌렀을 때 실행되는 함수
+// confirmation | warning => 버튼의 색상 구분, confirmation : 확인이 포인트 컬러, 취소가 일반 버튼 / warning : 확인이 일반 버튼, 취소가 포인트 컬러
+
+type ModalProps = {
+  title: string;
+  text1: string;
+  text2?: string;
+  text3?: string;
+  onClickHandler: () => void;
+  type: 'confirmation' | 'warning';
+};
+
+const ConfirmationModal: React.FC<ModalProps> = ({
+  title,
+  text1,
+  text2,
+  text3,
+  onClickHandler,
+  type,
+}) => {
+  const dispatch = useDispatch();
+  const onOff = useSelector((state: RootState) => {
+    return state.modal.open;
+  });
+  const submitHandler = () => {
+    onClickHandler();
+    dispatch(setClose(null));
+  };
+  const cancleHandler = () => {
+    dispatch(setClose(null));
+  };
+  return (
+    <S.ModalBackground OnOff={onOff}>
+      <S.ModalContainer>
+        <S.Title>
+          <h2>{title}</h2>
+        </S.Title>
+        <S.TextBox>
+          <p>{text1}</p>
+          {text2 && <p>{text2}</p>}
+          {text3 && <p>{text3}</p>}
+        </S.TextBox>
+        {type === 'confirmation' ? (
+          <S.BtnBox>
+            <YellowBtn type='button' onClick={submitHandler}>
+              확인
+            </YellowBtn>
+            <button type='button' onClick={cancleHandler}>
+              취소
+            </button>
+          </S.BtnBox>
+        ) : (
+          <S.BtnBox>
+            <button type='button' onClick={submitHandler}>
+              확인
+            </button>
+            <YellowBtn type='button' onClick={cancleHandler}>
+              취소
+            </YellowBtn>
+          </S.BtnBox>
+        )}
+      </S.ModalContainer>
+    </S.ModalBackground>
+  );
+};
+
+export default ConfirmationModal;

--- a/client/src/hooks/useDeleteUserProfile.ts
+++ b/client/src/hooks/useDeleteUserProfile.ts
@@ -3,8 +3,8 @@ import { UserProfileAPI } from '../api/client';
 
 const { deleteUserProfile } = UserProfileAPI;
 
-export const useDeleteUserProfile = () => {
-  // const queryClient = useQueryClient();
+export const useDeleteUserProfile = (userId: number) => {
+  const queryClient = useQueryClient();
   const { mutate: deleteUserProfileMutation } = useMutation(deleteUserProfile, {
     onMutate: () => {
       console.log('onMutate');
@@ -14,7 +14,7 @@ export const useDeleteUserProfile = () => {
     },
     onSuccess: (data) => {
       console.log(data, 'success');
-      // queryClient.invalidateQueries(['userProfile', userId]);
+      queryClient.invalidateQueries(['userProfile', userId]);
     },
     onSettled: () => {
       console.log('end');

--- a/client/src/hooks/useGetUserPortfolios.ts
+++ b/client/src/hooks/useGetUserPortfolios.ts
@@ -1,17 +1,40 @@
-import { useQuery } from '@tanstack/react-query';
-import { GetUserPortfolio } from '../types';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { PageParam } from '../types';
 import { UserPortfolioAPI } from '../api/client';
 
 const { getUserPortfolio } = UserPortfolioAPI;
 
-export const useGetUserPortfolios = (userId: number) => {
+export const useGetUserPortfolios = (userId: number, size: string, sortOption: string) => {
   const {
     isLoading: getUserPortfoliosLoading,
     isError: getUserPortfoliosError,
+    isFetched: getUserPortfoliosFetched,
     data: UserPortfolios,
-  } = useQuery<GetUserPortfolio[], Error>({
-    queryKey: ['userPortfolios', userId],
-    queryFn: () => getUserPortfolio(userId),
+    status: userPortfoliosStatus,
+    fetchNextPage: fetchNextUserPortfolios,
+    hasNextPage: hasNextUserPortfolios,
+  } = useInfiniteQuery({
+    queryKey: ['userPortfolios', userId, sortOption],
+    queryFn: ({ pageParam = 1 }: PageParam) =>
+      getUserPortfolio(userId, sortOption, pageParam, size),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.currentPage == lastPage.pageInfo.totalPages) {
+        return undefined;
+      } else {
+        return lastPage.currentPage + 1;
+      }
+    },
+    retry: (failureCount) => {
+      return failureCount < 1;
+    },
   });
-  return { getUserPortfoliosLoading, getUserPortfoliosError, UserPortfolios };
+  return {
+    getUserPortfoliosLoading,
+    getUserPortfoliosError,
+    getUserPortfoliosFetched,
+    UserPortfolios,
+    userPortfoliosStatus,
+    fetchNextUserPortfolios,
+    hasNextUserPortfolios,
+  };
 };

--- a/client/src/hooks/useGetUserProfile.ts
+++ b/client/src/hooks/useGetUserProfile.ts
@@ -12,7 +12,7 @@ export const useGetUserProfile = (userId: number) => {
     isError: getUserProfileError,
     data: UserProfile,
   } = useQuery<GetUserProfile, Error>({
-    queryKey: ['UserProfile', userId],
+    queryKey: ['userProfile', userId],
     queryFn: () => getUserProfile(userId),
     onError: () => {
       console.error('해당하는 유저를 찾을 수 없습니다.');

--- a/client/src/hooks/usePatchUserProfile.ts
+++ b/client/src/hooks/usePatchUserProfile.ts
@@ -1,10 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PatchUserProfile } from '../types';
 import { UserProfileAPI } from '../api/client';
 
 const { patchUserProfile } = UserProfileAPI;
 
-export const usePatchUserProfile = () => {
+export const usePatchUserProfile = (userId: number) => {
+  const queryClient = useQueryClient();
   const { mutate: patchUserProfileMutation } = useMutation(patchUserProfile, {
     onMutate: () => {
       console.log('onMutate');
@@ -14,6 +15,7 @@ export const usePatchUserProfile = () => {
     },
     onSuccess: (data) => {
       console.log(data, 'success');
+      queryClient.invalidateQueries(['userProfile', userId]);
     },
     onSettled: () => {
       console.log('end');

--- a/client/src/hooks/usePostUserComment.ts
+++ b/client/src/hooks/usePostUserComment.ts
@@ -6,7 +6,7 @@ import { getUserIdFromAccessToken } from '../utils/getUserIdFromAccessToken';
 const { postUserComment } = UserCommentsAPI;
 
 export const usePostUserComment = (userId: number) => {
-  const token = useAppSelector((state) => state.login.accessToken);
+  const token = localStorage.getItem('accessToken');
   const isLogin = useAppSelector((state) => state.login.isLogin);
   const writerId = getUserIdFromAccessToken(isLogin, token);
 
@@ -21,6 +21,7 @@ export const usePostUserComment = (userId: number) => {
     onSuccess: (data) => {
       console.log(data, 'success');
       queryClient.invalidateQueries(['userComments', userId]);
+      queryClient.invalidateQueries(['commentsToUser', userId]);
     },
     onSettled: () => {
       console.log('end');

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -3,13 +3,15 @@ import themeReducer from '../store/slice/themeSlice';
 import loginReducer from '../store/slice/loginSlice';
 import { persistReducer, FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
-import editUserProfileSlice from './slice/editUserProfileSlice';
+import editUserProfileReducer from './slice/editUserProfileSlice';
+import modalReducer from './slice/modalSlice';
 
 // reducer를 여기에 추가하시면 됩니다
 const rootReducer = combineReducers({
   theme: themeReducer,
   login: loginReducer,
-  editUserProfile: editUserProfileSlice,
+  editUserProfile: editUserProfileReducer,
+  modal: modalReducer,
 });
 
 const persistConfig = {
@@ -17,7 +19,7 @@ const persistConfig = {
   storage,
 
   // persist 적용하기
-  whitelist: ['theme', 'login', 'editUserProfile'],
+  whitelist: ['theme', 'login', 'editUserProfile', 'modal'],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/client/src/store/slice/editUserProfileSlice.ts
+++ b/client/src/store/slice/editUserProfileSlice.ts
@@ -4,7 +4,7 @@ import { createSlice } from '@reduxjs/toolkit';
 // ! : 다른 방법을 발견하면 삭제 예정.
 type UserInfo = {
   name: string;
-  profileImg: File | null;
+  profileImg: string;
   about: string;
   jobStatus: string;
   gitLink: string;
@@ -13,14 +13,14 @@ type UserInfo = {
 
 const initialState: UserInfo = {
   name: '',
-  profileImg: null,
+  profileImg: '',
   about: '',
   jobStatus: '',
   gitLink: '',
   blogLink: '',
 };
 
-const EditUserProfileSlice = createSlice({
+const editUserProfileSlice = createSlice({
   name: 'editUserProfile',
   initialState,
   reducers: {
@@ -28,6 +28,7 @@ const EditUserProfileSlice = createSlice({
       state.name = action.payload;
     },
     setImg: (state, action) => {
+      console.log(action.payload);
       state.profileImg = action.payload;
     },
     setAbout: (state, action) => {
@@ -54,6 +55,6 @@ const EditUserProfileSlice = createSlice({
 });
 
 export const { setName, setImg, setAbout, setJobStatus, setGit, setBlog } =
-  EditUserProfileSlice.actions;
+  editUserProfileSlice.actions;
 
-export default EditUserProfileSlice.reducer;
+export default editUserProfileSlice.reducer;

--- a/client/src/store/slice/modalSlice.ts
+++ b/client/src/store/slice/modalSlice.ts
@@ -1,0 +1,29 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+// ! : state와 setState를 둘 다 props로 전달해야하는 문제 때문에 적용
+// ! : 다른 더 좋은 방법을 발견하면 삭제
+// ! : 다른 분들에게 Modal 기능을 사용하는지 물어보기(삭제 관련된 부분에서)
+type ModalStatus = {
+  open: boolean;
+};
+
+const initialState: ModalStatus = {
+  open: false,
+};
+
+const ModalSlice = createSlice({
+  name: 'modal',
+  initialState,
+  reducers: {
+    setOpen: (state, action: PayloadAction<null>) => {
+      state.open = true;
+    },
+    setClose: (state, action: PayloadAction<null>) => {
+      state.open = false;
+    },
+  },
+});
+
+export const { setOpen, setClose } = ModalSlice.actions;
+
+export default ModalSlice.reducer;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -26,6 +26,12 @@ export type GetUserPortfolio = {
   updatedAt: number[];
 };
 
+export type GetUserPortfolioPage = {
+  currentPage: number;
+  data: GetUserPortfolio[];
+  pageInfo: PageInfo;
+};
+
 export type GetUserComment = {
   // 댓글 공통
   userId: number;
@@ -56,7 +62,7 @@ export type PostUserComment = {
 export type PatchUserProfile = {
   userId: number;
   name: string;
-  profileImg: File | null;
+  profileImg: string;
   gitLink: string;
   blogLink: string;
   jobStatus: string;


### PR DESCRIPTION
### Branch
fe-feat/유저페이지/#70 => fe

### 참고 사항
- 유저 포트폴리오 무한 스크롤 기능 구현
- 유저 이미지 수정 기능 구현
- 유저 프로필 Auth 기능 추가
- User 관련 QueryKey 수정(userId 추가)
- 버튼 클릭시 확인 모달 추가(components/common/ConfirmationModal.tsx) 및 회원 탈퇴시 모달 적용
- 아직 유저 코멘트 부분은 무한 스크롤 및 Auth 기능 미적용 상태