### PR TITLE
fix: 유저페이지 포트폴리오 무한스크롤 오류 해결

### DIFF
--- a/client/src/components/User/Portfolio.tsx
+++ b/client/src/components/User/Portfolio.tsx
@@ -1,9 +1,10 @@
 import * as S from './Portfolio.style';
 import Card from '../common/Card';
 import Sort from '../Home/Sort';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useGetUserPortfolios } from '../../hooks/useGetUserPortfolios';
 import Loading from '../common/Loading';
+import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 
 type IdProps = {
   userId: number;
@@ -14,45 +15,25 @@ const Portfolio: React.FC<IdProps> = ({ userId }) => {
   const {
     UserPortfolios,
     getUserPortfoliosError,
+    getUserPortfoliosFetching,
+    ErrorInfo,
+    userPortfoliosStatus,
     fetchNextUserPortfolios,
     hasNextUserPortfolios,
-    getUserPortfoliosFetched,
-    getUserPortfoliosLoading,
+    getUserPortfolioLoading,
   } = useGetUserPortfolios(userId, '6', orderName);
 
   const targetRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    const options = {
-      root: null,
-      rootMargin: '100px',
-      threshold: 0.3,
-    };
+  useInfiniteScroll({
+    targetRef,
+    isPortfoliosError: getUserPortfoliosError,
+    isPortfolioFetching: getUserPortfoliosFetching,
+    hasNextPortfolio: hasNextUserPortfolios,
+    fetchNextPortfolio: fetchNextUserPortfolios,
+  });
 
-    const handleIntersect: IntersectionObserverCallback = (
-      entries: IntersectionObserverEntry[],
-    ) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting && !getUserPortfoliosError && hasNextUserPortfolios) {
-          fetchNextUserPortfolios();
-        }
-      });
-    };
-
-    const observer = new IntersectionObserver(handleIntersect, options);
-
-    if (targetRef.current) {
-      observer.observe(targetRef.current);
-    }
-
-    return () => {
-      if (targetRef.current) {
-        observer.unobserve(targetRef.current);
-      }
-    };
-  }, [fetchNextUserPortfolios, hasNextUserPortfolios, getUserPortfoliosFetched]);
-
-  if (getUserPortfoliosLoading) {
+  if (getUserPortfolioLoading) {
     return (
       <>
         <Sort setSortOption={setOrderName} />
@@ -65,9 +46,9 @@ const Portfolio: React.FC<IdProps> = ({ userId }) => {
 
   return (
     <>
+      <Sort setSortOption={setOrderName} />
       {UserPortfolios && (
         <>
-          <Sort setSortOption={setOrderName} />
           {UserPortfolios.pages[0].data.length === 0 ? (
             <S.ErrorContainer>현재 작성된 포트폴리오가 없습니다.</S.ErrorContainer>
           ) : (
@@ -87,6 +68,9 @@ const Portfolio: React.FC<IdProps> = ({ userId }) => {
                 )),
               )}
               <S.Target ref={targetRef} />
+              {/* {!getUserPortfoliosFetching && !getUserPortfoliosError && !hasNextUserPortfolios && (
+                <p>마지막 게시글입니다.</p>
+              )} */}
             </S.PortfolioContainer>
           )}
         </>

--- a/client/src/hooks/useGetUserPortfolios.ts
+++ b/client/src/hooks/useGetUserPortfolios.ts
@@ -1,19 +1,21 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { PageParam } from '../types';
+import { GetUserPortfolioPage, PageParam } from '../types';
 import { UserPortfolioAPI } from '../api/client';
+import { AxiosError } from 'axios';
 
 const { getUserPortfolio } = UserPortfolioAPI;
 
 export const useGetUserPortfolios = (userId: number, size: string, sortOption: string) => {
   const {
-    isLoading: getUserPortfoliosLoading,
-    isError: getUserPortfoliosError,
-    isFetched: getUserPortfoliosFetched,
     data: UserPortfolios,
+    isError: getUserPortfoliosError,
+    isFetching: getUserPortfoliosFetching,
+    error: ErrorInfo,
     status: userPortfoliosStatus,
     fetchNextPage: fetchNextUserPortfolios,
     hasNextPage: hasNextUserPortfolios,
-  } = useInfiniteQuery({
+    isLoading: getUserPortfolioLoading,
+  } = useInfiniteQuery<GetUserPortfolioPage, AxiosError>({
     queryKey: ['userPortfolios', userId, sortOption],
     queryFn: ({ pageParam = 1 }: PageParam) =>
       getUserPortfolio(userId, sortOption, pageParam, size),
@@ -27,12 +29,13 @@ export const useGetUserPortfolios = (userId: number, size: string, sortOption: s
     retry: false,
   });
   return {
-    getUserPortfoliosLoading,
-    getUserPortfoliosError,
-    getUserPortfoliosFetched,
     UserPortfolios,
+    getUserPortfoliosError,
+    getUserPortfoliosFetching,
+    ErrorInfo,
     userPortfoliosStatus,
     fetchNextUserPortfolios,
     hasNextUserPortfolios,
+    getUserPortfolioLoading,
   };
 };

--- a/client/src/hooks/useInfiniteScroll.ts
+++ b/client/src/hooks/useInfiniteScroll.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { GetPortfolioPage } from '../types/index';
+import { GetPortfolioPage, GetUserPortfolioPage } from '../types/index';
 import type { FetchNextPageOptions, InfiniteQueryObserverResult } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
@@ -10,7 +10,7 @@ type useInfiniteScrollProps = {
   hasNextPortfolio: boolean | undefined;
   fetchNextPortfolio: (
     options?: FetchNextPageOptions | undefined,
-  ) => Promise<InfiniteQueryObserverResult<GetPortfolioPage, AxiosError>>;
+  ) => Promise<InfiniteQueryObserverResult<GetPortfolioPage | GetUserPortfolioPage, AxiosError>>;
 };
 
 export function useInfiniteScroll({


### PR DESCRIPTION
### Branch 
fe-feat/home/#70 => fe 

### 참고사항 
* 정렬 버튼이 제대로 작동하지 않는 문제 개선
* useInfiniteScroll의 useInfiniteScrollProps : fetchNextPortfolio 에 GetUserPortfolioPage 타입 추가