### PR TITLE
feat: 유저 댓글 무한스크롤 적용

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -17,7 +17,6 @@ import {
   PostPortfolioComment,
   PatchPortfolioComment,
   GetUserProfile,
-  GetUserComment,
   PatchUserProfile,
   DeletePortfolioComment,
   PostPortfolio,
@@ -29,6 +28,7 @@ import {
   GetUserPortfolioPage,
   SignUp,
   Login,
+  GetUserCommentPage,
 } from '../types/index';
 
 const { refreshUrl } = URL;
@@ -254,7 +254,6 @@ export const UserProfileAPI = {
     return userProfileData.data.data;
   },
   postUserImg: async (userId: number, userImg: File) => {
-    // ! : 파일은 form 데이터로 전송
     const profileImg = new FormData();
     profileImg.append('profileImg', userImg);
     const axiosConfig = {
@@ -302,23 +301,37 @@ export const UserPortfolioAPI = {
 };
 
 export const UserCommentsAPI = {
-  getUserComments: async (userId: number): Promise<GetUserComment[]> => {
+  getUserComments: async (
+    userId: number,
+    page: number,
+    size: string,
+  ): Promise<GetUserCommentPage> => {
     const userCommentsData = await tokenClient.get(
-      `/api/usercomments/users/${userId}?page=1&size=10`,
+      `/api/usercomments/users/${userId}?page=${page}&size=${size}`,
     );
-    return userCommentsData.data.data;
+    return { ...userCommentsData.data, currentPage: page };
   },
   // * : 한 유저가 다른 사람의 포트폴리에 작성한 댓글
-  getCommentsToPortfolio: async (userId: number): Promise<GetUserComment[]> => {
-    const commentsToPortfolioData = await tokenClient.get(`/api/portfoliocomments/users/${userId}`);
-    return commentsToPortfolioData.data.data;
+  getCommentsToPortfolio: async (
+    userId: number,
+    page: number,
+    size: string,
+  ): Promise<GetUserCommentPage> => {
+    const commentsToPortfolioData = await tokenClient.get(
+      `/api/portfoliocomments/users/${userId}?page=${page}&size=${size}`,
+    );
+    return { ...commentsToPortfolioData.data, currentPage: page };
   },
   // * : 한 유저가 다른 사람에게 작성한 댓글
-  getCommentsToUser: async (userId: number): Promise<GetUserComment[]> => {
+  getCommentsToUser: async (
+    userId: number,
+    page: number,
+    size: string,
+  ): Promise<GetUserCommentPage> => {
     const commentsToUserData = await tokenClient.get(
-      `/api/usercomments/writers/${userId}?page=1&size=10`,
+      `/api/usercomments/writers/${userId}?page=${page}&size=${size}`,
     );
-    return commentsToUserData.data.data;
+    return { ...commentsToUserData.data, currentPage: page };
   },
   postUserComment: async ({ userId, writerId, content, userCommentStatus }: PostUserComment) => {
     return await tokenClient.post('/api/usercomments', {
@@ -341,7 +354,6 @@ export const UserCommentsAPI = {
         : { portfolioCommentId: commentId, userId, portfolioId: pathId, content },
     );
   },
-  // ! : 전달되는게 어떤 id값인지 확인 필요
   deleteUserComment: async ({ commentId, path }: DeleteUserComment) => {
     await tokenClient.delete(`/api/${path}/${commentId}`);
   },

--- a/client/src/components/User/CommentContainer.style.ts
+++ b/client/src/components/User/CommentContainer.style.ts
@@ -109,3 +109,7 @@ export const CategoryBtns = styled.div`
     }
   }
 `;
+
+export const Target = styled.div`
+  height: 1px;
+`;

--- a/client/src/components/User/CommentContainer.tsx
+++ b/client/src/components/User/CommentContainer.tsx
@@ -1,14 +1,13 @@
 import * as S from './CommentContainer.style';
-import CommentItem from './CommentItem';
 import { ChangeEvent, useState } from 'react';
-import { useGetUserComments } from '../../hooks/useGetUserComment';
-import { useGetCommentsToPortfolio } from '../../hooks/useGetCommentsToPortfolio';
-import { useGetCommentsToUser } from '../../hooks/useGetCommentsToUser';
 import { usePostUserComment } from '../../hooks/usePostUserComment';
 import { toast } from 'react-toastify';
 import { useAppSelector } from '../../hooks/reduxHook';
+import CommentsOfUser from './CommentsOfUser';
+import CommentsToUser from './CommentsToUser';
+import CommentsToPortfolio from './CommentsToPortfolio';
 
-type CommentProps = {
+export type CommentProps = {
   userId: number;
 };
 
@@ -36,10 +35,6 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
     setContent(e.target.value);
   };
 
-  const { UserComments } = useGetUserComments(userId);
-  const { CommentsToPortfolio } = useGetCommentsToPortfolio(userId);
-  const { CommentsToUser } = useGetCommentsToUser(userId);
-
   return (
     <S.CommentContainer>
       <S.SelectBtn>
@@ -52,26 +47,7 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
       </S.SelectBtn>
       {selectComment ? (
         <>
-          {UserComments && (
-            <>
-              {UserComments.length > 0 ? (
-                <S.Comments CommentLen={UserComments.length}>
-                  {UserComments.map((data) => (
-                    <CommentItem
-                      key={data.userCommentId}
-                      data={data}
-                      path='usercomments'
-                      link={false}
-                    />
-                  ))}
-                </S.Comments>
-              ) : (
-                <>
-                  <p>작성된 댓글이 없습니다.</p>
-                </>
-              )}
-            </>
-          )}
+          <CommentsOfUser userId={userId} />
           <S.CommentAdd onSubmit={addHandler}>
             <label htmlFor='Comment'></label>
             <textarea
@@ -102,53 +78,7 @@ const CommentContainer: React.FC<CommentProps> = ({ userId }) => {
               포트폴리오
             </button>
           </S.CategoryBtns>
-          {category ? (
-            <>
-              {CommentsToUser && (
-                <>
-                  {CommentsToUser.length > 0 ? (
-                    <S.Comments CommentLen={CommentsToUser.length}>
-                      {CommentsToUser.map((data) => (
-                        <CommentItem
-                          key={data.userCommentId}
-                          data={data}
-                          path='usercomments'
-                          link={true}
-                        />
-                      ))}
-                    </S.Comments>
-                  ) : (
-                    <>
-                      <p>작성한 댓글이 없습니다.</p>
-                    </>
-                  )}
-                </>
-              )}
-            </>
-          ) : (
-            <>
-              {CommentsToPortfolio && (
-                <>
-                  {CommentsToPortfolio.length > 0 ? (
-                    <S.Comments CommentLen={CommentsToPortfolio.length}>
-                      {CommentsToPortfolio.map((data) => (
-                        <CommentItem
-                          key={data.userCommentId}
-                          data={data}
-                          path='portfoliocomments'
-                          link={true}
-                        />
-                      ))}
-                    </S.Comments>
-                  ) : (
-                    <>
-                      <p>작성한 댓글이 없습니다.</p>
-                    </>
-                  )}
-                </>
-              )}
-            </>
-          )}
+          {category ? <CommentsToUser userId={userId} /> : <CommentsToPortfolio userId={userId} />}
         </>
       )}
     </S.CommentContainer>

--- a/client/src/components/User/CommentItem.tsx
+++ b/client/src/components/User/CommentItem.tsx
@@ -6,9 +6,9 @@ import { GetUserComment } from '../../types';
 import { useRouter } from '../../hooks/useRouter';
 
 type CommentItemProps = {
-  data: GetUserComment;
-  path: string;
+  path: 'usercomments' | 'portfoliocomments';
   link: boolean;
+  data: GetUserComment;
 };
 
 const CommentItem: React.FC<CommentItemProps> = ({ data, path, link }) => {
@@ -67,12 +67,6 @@ const CommentItem: React.FC<CommentItemProps> = ({ data, path, link }) => {
     CommentRef.current?.focus();
   }, [onEdit]);
 
-  // 비밀글 체크가 되어있는 경우, 작성자 & 수령자(?)를 제외하곤 *********** 표시 혹은 댓글을 아예 미표시
-  // editText 부분이랑 CommentUser 부분만 ******* 으로 표시하는게 더 조건 걸기가 쉬울 것 같음.
-
-  // auth : 수정 가능
-  // deletable : 삭제 / 수정 가능 (비밀글 열람 가능)
-
   if (delConfirm) {
     return (
       <S.CommentItem>
@@ -97,6 +91,9 @@ const CommentItem: React.FC<CommentItemProps> = ({ data, path, link }) => {
   return (
     <S.CommentItem>
       {data.deletable && <S.DelBtn onClick={onEdit ? onCancelHandler : delConfimHandler} />}
+      {path === 'portfoliocomments' && data.auth && (
+        <S.DelBtn onClick={onEdit ? onCancelHandler : delConfimHandler} />
+      )}
       {data.auth && !onEdit && <S.EditBtn onClick={onEditHandler} />}
       {onEdit && <S.SubmitBtn onClick={onSubmitHandler} />}
       {onEdit && (

--- a/client/src/components/User/CommentsOfUser.tsx
+++ b/client/src/components/User/CommentsOfUser.tsx
@@ -1,0 +1,55 @@
+import * as S from './CommentContainer.style';
+import { useRef } from 'react';
+import { useCommentsInfiniteScroll } from '../../hooks/useCommentsInfiniteScroll';
+import { useGetUserComments } from '../../hooks/useGetUserComment';
+import CommentItem from './CommentItem';
+
+const CommentsOfUser: React.FC<{ userId: number }> = ({ userId }) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    UserComments,
+    getUserCommentError,
+    getUserCommentFetching,
+    hasNextUserComment,
+    fetchNextUserComment,
+  } = useGetUserComments(userId, '6');
+
+  useCommentsInfiniteScroll({
+    targetRef,
+    getUserCommentError,
+    getUserCommentFetching,
+    hasNextUserComment,
+    fetchNextUserComment,
+  });
+
+  return (
+    <>
+      {UserComments && (
+        <>
+          {UserComments.pages.length > 0 ? (
+            <S.Comments CommentLen={UserComments.pages[0].data.length}>
+              {UserComments.pages.map((page) =>
+                page.data.map((data) => (
+                  <CommentItem
+                    key={data.userCommentId}
+                    data={data}
+                    path='usercomments'
+                    link={false}
+                  />
+                )),
+              )}
+              <S.Target ref={targetRef} />
+            </S.Comments>
+          ) : (
+            <>
+              <p>작성된 댓글이 없습니다.</p>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default CommentsOfUser;

--- a/client/src/components/User/CommentsToPortfolio.tsx
+++ b/client/src/components/User/CommentsToPortfolio.tsx
@@ -1,0 +1,55 @@
+import * as S from './CommentContainer.style';
+import { useRef } from 'react';
+import { useCommentsInfiniteScroll } from '../../hooks/useCommentsInfiniteScroll';
+import CommentItem from './CommentItem';
+import { useGetCommentsToPortfolio } from '../../hooks/useGetCommentsToPortfolio';
+
+const CommentsToPortfolio: React.FC<{ userId: number }> = ({ userId }) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    CommentsToPortfolio,
+    getCommentsToPortfolioError,
+    getCommentsToPortfolioFetching,
+    hasNextCommentsToPortfolio,
+    fetchNextCommentsToPortfolio,
+  } = useGetCommentsToPortfolio(userId, '6');
+
+  useCommentsInfiniteScroll({
+    targetRef,
+    getUserCommentError: getCommentsToPortfolioError,
+    getUserCommentFetching: getCommentsToPortfolioFetching,
+    hasNextUserComment: hasNextCommentsToPortfolio,
+    fetchNextUserComment: fetchNextCommentsToPortfolio,
+  });
+
+  return (
+    <>
+      {CommentsToPortfolio && (
+        <>
+          {CommentsToPortfolio.pages.length > 0 ? (
+            <S.Comments CommentLen={CommentsToPortfolio.pages[0].data.length}>
+              {CommentsToPortfolio.pages.map((page) =>
+                page.data.map((data) => (
+                  <CommentItem
+                    key={data.portfolioCommentId}
+                    data={data}
+                    path='portfoliocomments'
+                    link={true}
+                  />
+                )),
+              )}
+              <S.Target ref={targetRef} />
+            </S.Comments>
+          ) : (
+            <>
+              <p>작성된 댓글이 없습니다.</p>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default CommentsToPortfolio;

--- a/client/src/components/User/CommentsToUser.tsx
+++ b/client/src/components/User/CommentsToUser.tsx
@@ -1,0 +1,55 @@
+import * as S from './CommentContainer.style';
+import { useRef } from 'react';
+import { useCommentsInfiniteScroll } from '../../hooks/useCommentsInfiniteScroll';
+import CommentItem from './CommentItem';
+import { useGetCommentsToUser } from '../../hooks/useGetCommentsToUser';
+
+const CommentsToUser: React.FC<{ userId: number }> = ({ userId }) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    CommentsToUser,
+    getCommentsToUserError,
+    getCommentsToUserFetching,
+    hasNextCommentsToUser,
+    fetchNextCommentsToUser,
+  } = useGetCommentsToUser(userId, '6');
+
+  useCommentsInfiniteScroll({
+    targetRef,
+    getUserCommentError: getCommentsToUserError,
+    getUserCommentFetching: getCommentsToUserFetching,
+    hasNextUserComment: hasNextCommentsToUser,
+    fetchNextUserComment: fetchNextCommentsToUser,
+  });
+
+  return (
+    <>
+      {CommentsToUser && (
+        <>
+          {CommentsToUser.pages.length > 0 ? (
+            <S.Comments CommentLen={CommentsToUser.pages[0].data.length}>
+              {CommentsToUser.pages.map((page) =>
+                page.data.map((data) => (
+                  <CommentItem
+                    key={data.userCommentId}
+                    data={data}
+                    path='usercomments'
+                    link={true}
+                  />
+                )),
+              )}
+              <S.Target ref={targetRef} />
+            </S.Comments>
+          ) : (
+            <>
+              <p>작성된 댓글이 없습니다.</p>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default CommentsToUser;

--- a/client/src/components/User/UserInfo.style.ts
+++ b/client/src/components/User/UserInfo.style.ts
@@ -21,7 +21,7 @@ export const SelectBtn = styled.div`
     box-shadow: 0;
     transition: all 0.3s;
     &.select {
-      box-shadow: 0 -1px 0.5px ${(props) => props.theme.themeStyle.fontColor} inset;
+      box-shadow: 0 -1px 0px ${(props) => props.theme.themeStyle.fontColor} inset;
       transition: all 0.3s;
     }
   }

--- a/client/src/hooks/useCommentsInfiniteScroll.ts
+++ b/client/src/hooks/useCommentsInfiniteScroll.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { GetUserCommentPage } from '../types/index';
+import type { FetchNextPageOptions, InfiniteQueryObserverResult } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+type useCommentsInfiniteScrollProps = {
+  targetRef: React.MutableRefObject<HTMLDivElement | null>;
+  getUserCommentError: boolean;
+  getUserCommentFetching: boolean;
+  hasNextUserComment: boolean | undefined;
+  fetchNextUserComment: (
+    options?: FetchNextPageOptions | undefined,
+  ) => Promise<InfiniteQueryObserverResult<GetUserCommentPage, AxiosError>>;
+};
+
+export function useCommentsInfiniteScroll({
+  targetRef,
+  getUserCommentError,
+  getUserCommentFetching,
+  hasNextUserComment,
+  fetchNextUserComment,
+}: useCommentsInfiniteScrollProps) {
+  useEffect(() => {
+    const options = {
+      root: null,
+      rootMargin: '100px',
+      threshold: 0.3,
+    };
+
+    const handleIntersect: IntersectionObserverCallback = (
+      entries: IntersectionObserverEntry[],
+    ) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && !getUserCommentError && hasNextUserComment) {
+          fetchNextUserComment();
+        }
+      });
+    };
+
+    const observer = new IntersectionObserver(handleIntersect, options);
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    return () => {
+      if (targetRef.current) {
+        observer.unobserve(targetRef.current);
+      }
+    };
+  }, [fetchNextUserComment, hasNextUserComment, getUserCommentFetching]);
+}

--- a/client/src/hooks/useGetCommentsToPortfolio.ts
+++ b/client/src/hooks/useGetCommentsToPortfolio.ts
@@ -1,17 +1,39 @@
-import { useQuery } from '@tanstack/react-query';
-import { GetUserComment } from '../types';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { GetUserCommentPage, PageParam } from '../types';
 import { UserCommentsAPI } from '../api/client';
+import { AxiosError } from 'axios';
 
 const { getCommentsToPortfolio } = UserCommentsAPI;
 
-export const useGetCommentsToPortfolio = (userId: number) => {
+export const useGetCommentsToPortfolio = (userId: number, size: string) => {
   const {
-    isLoading: getCommentsToPortfolioLoading,
-    isError: getCommentsToPortfolioError,
     data: CommentsToPortfolio,
-  } = useQuery<GetUserComment[], Error>({
+    isError: getCommentsToPortfolioError,
+    isFetching: getCommentsToPortfolioFetching,
+    error: ErrorInfo,
+    status: CommentsToPortfolioStatus,
+    fetchNextPage: fetchNextCommentsToPortfolio,
+    hasNextPage: hasNextCommentsToPortfolio,
+    isLoading: getCommentsToPortfolioLoading,
+  } = useInfiniteQuery<GetUserCommentPage, AxiosError>({
     queryKey: ['commentsToPortfolio', userId],
-    queryFn: () => getCommentsToPortfolio(userId),
+    queryFn: ({ pageParam = 1 }: PageParam) => getCommentsToPortfolio(userId, pageParam, size),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.currentPage === lastPage.pageInfo.totalPages) {
+        return undefined;
+      } else {
+        return lastPage.currentPage + 1;
+      }
+    },
   });
-  return { getCommentsToPortfolioLoading, getCommentsToPortfolioError, CommentsToPortfolio };
+  return {
+    getCommentsToPortfolioLoading,
+    getCommentsToPortfolioError,
+    CommentsToPortfolio,
+    getCommentsToPortfolioFetching,
+    ErrorInfo,
+    CommentsToPortfolioStatus,
+    fetchNextCommentsToPortfolio,
+    hasNextCommentsToPortfolio,
+  };
 };

--- a/client/src/hooks/useGetCommentsToUser.ts
+++ b/client/src/hooks/useGetCommentsToUser.ts
@@ -1,17 +1,39 @@
-import { useQuery } from '@tanstack/react-query';
-import { GetUserComment } from '../types';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { GetUserCommentPage, PageParam } from '../types';
 import { UserCommentsAPI } from '../api/client';
+import { AxiosError } from 'axios';
 
 const { getCommentsToUser } = UserCommentsAPI;
 
-export const useGetCommentsToUser = (userId: number) => {
+export const useGetCommentsToUser = (userId: number, size: string) => {
   const {
-    isLoading: getCommentsToUserLoading,
-    isError: getCommentsToUserError,
     data: CommentsToUser,
-  } = useQuery<GetUserComment[], Error>({
+    isError: getCommentsToUserError,
+    isFetching: getCommentsToUserFetching,
+    error: ErrorInfo,
+    status: CommentsToUserStatus,
+    fetchNextPage: fetchNextCommentsToUser,
+    hasNextPage: hasNextCommentsToUser,
+    isLoading: getCommentsToUserLoading,
+  } = useInfiniteQuery<GetUserCommentPage, AxiosError>({
     queryKey: ['commentsToUser', userId],
-    queryFn: () => getCommentsToUser(userId),
+    queryFn: ({ pageParam = 1 }: PageParam) => getCommentsToUser(userId, pageParam, size),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.currentPage === lastPage.pageInfo.totalPages) {
+        return undefined;
+      } else {
+        return lastPage.currentPage + 1;
+      }
+    },
   });
-  return { getCommentsToUserLoading, getCommentsToUserError, CommentsToUser };
+  return {
+    getCommentsToUserLoading,
+    getCommentsToUserError,
+    CommentsToUser,
+    getCommentsToUserFetching,
+    ErrorInfo,
+    CommentsToUserStatus,
+    fetchNextCommentsToUser,
+    hasNextCommentsToUser,
+  };
 };

--- a/client/src/hooks/useGetUserComment.ts
+++ b/client/src/hooks/useGetUserComment.ts
@@ -1,17 +1,39 @@
-import { useQuery } from '@tanstack/react-query';
-import { GetUserComment } from '../types';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { GetUserCommentPage, PageParam } from '../types';
 import { UserCommentsAPI } from '../api/client';
+import { AxiosError } from 'axios';
 
 const { getUserComments } = UserCommentsAPI;
 
-export const useGetUserComments = (userId: number) => {
+export const useGetUserComments = (userId: number, size: string) => {
   const {
-    isLoading: getUserCommentLoading,
-    isError: getUserCommentError,
     data: UserComments,
-  } = useQuery<GetUserComment[], Error>({
+    isError: getUserCommentError,
+    isFetching: getUserCommentFetching,
+    error: ErrorInfo,
+    status: userCommentStatus,
+    fetchNextPage: fetchNextUserComment,
+    hasNextPage: hasNextUserComment,
+    isLoading: getUserCommentLoading,
+  } = useInfiniteQuery<GetUserCommentPage, AxiosError>({
     queryKey: ['userComments', userId],
-    queryFn: () => getUserComments(userId),
+    queryFn: ({ pageParam = 1 }: PageParam) => getUserComments(userId, pageParam, size),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.currentPage === lastPage.pageInfo.totalPages) {
+        return undefined;
+      } else {
+        return lastPage.currentPage + 1;
+      }
+    },
   });
-  return { getUserCommentLoading, getUserCommentError, UserComments };
+  return {
+    getUserCommentLoading,
+    getUserCommentError,
+    UserComments,
+    getUserCommentFetching,
+    ErrorInfo,
+    userCommentStatus,
+    fetchNextUserComment,
+    hasNextUserComment,
+  };
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -58,6 +58,12 @@ export type GetUserComment = {
   portfolioId?: number;
 };
 
+export type GetUserCommentPage = {
+  currentPage: number;
+  data: GetUserComment[];
+  pageInfo: PageInfo;
+};
+
 export type PostUserComment = {
   userId: number;
   writerId: number;


### PR DESCRIPTION
### Branch 
fe-feat/home/#70 => fe 

### 참고사항 
* 유저 댓글 무한스크롤 기능 적용
* 유저 댓글 종류별로 분할(CommentsOfUser, CommentsToUser, CommentsToPortfolio)
* 유저가 작성한 포트폴리오 댓글 삭제버튼이 나타나지 않는 오류 수정
* 선택 버튼의 box-shadow 수정