### PR TITLE
design: 로딩 스피너 중앙정렬

### DIFF
--- a/client/src/components/common/Loading.style.ts
+++ b/client/src/components/common/Loading.style.ts
@@ -6,7 +6,7 @@ import { COLOR } from '../../constants';
 const { mainColor } = COLOR;
 
 export const StyledLoading = styled.div`
-  display: inline-block;
+  display: block;
   position: relative;
   margin: 8rem auto;
   &::after {
@@ -15,7 +15,7 @@ export const StyledLoading = styled.div`
     border-radius: 50%;
     width: 100px;
     height: 100px;
-    margin: 8px;
+    margin: 8px auto;
     box-sizing: border-box;
     border: 32px solid ${mainColor};
     border-color: ${mainColor} transparent ${mainColor} transparent;

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -13,6 +13,7 @@ export const COLOR = {
   divider: '#F3F3F3', // light grey
   cardColor: '#303030', // charcoal
 } as const;
+
 export const THEME = {
   dark: 'dark',
   light: 'light',


### PR DESCRIPTION
### Branch 
khkh0109/fe-feat/fix-loading => fe

### 문제 
로딩 스피너가 화면 왼쪽에 치우쳐짐 

### 참고사항 
* 글로벌 스타일의 body에 flex로 중앙정렬을 시도했으나 다른 레이아웃에도 영향을 주어서 로딩 스피너의 margin으로 중앙정렬을 했습니다. 

### 변경한 부분 
* StyledLoading의 display를 block으로 변경해 양 옆에 마진을 주었습니다. 
* 마진을 양 옆에 auto로 배치해 중앙정렬을 했습니다. 

* 변경후
<img width="487" alt="스크린샷 2023-08-08 오후 3 22 20" src="https://github.com/codestates-seb/seb43_main_001/assets/77181642/2f050d46-e68d-449c-abf8-a2a4853fe685">

